### PR TITLE
Fixing a bug with duplicate entries in menu

### DIFF
--- a/MobileCRM/MobileCRM.Shared/Pages/MenuPage.cs
+++ b/MobileCRM/MobileCRM.Shared/Pages/MenuPage.cs
@@ -15,7 +15,7 @@ namespace MobileCRM.Shared.Pages
 
     public class MenuPage : ContentPage
     {
-        static readonly List<OptionItem> OptionItems = new List<OptionItem>();
+        readonly List<OptionItem> OptionItems = new List<OptionItem>();
 
         public ListView Menu { get; set; }
 


### PR DESCRIPTION
Because OptionItems was static if you exit the app using the back button and resume it, duplicate entries would get added.
