### PR TITLE
[formsgallery] Fix BoldSystemFontOfSize obsolete warning

### DIFF
--- a/FormsGallery/FormsGallery/FormsGallery/AbsoluteLayoutDemoPage.cs
+++ b/FormsGallery/FormsGallery/FormsGallery/AbsoluteLayoutDemoPage.cs
@@ -14,7 +14,7 @@ namespace FormsGallery
             Label header = new Label
             {
                 Text = "AbsoluteLayout",
-                Font = Font.BoldSystemFontOfSize(40),
+                Font = Font.SystemFontOfSize(40, FontAttributes.Bold),
                 HorizontalOptions = LayoutOptions.Center
             };
 

--- a/FormsGallery/FormsGallery/FormsGallery/ActivityIndicatorDemoPage.cs
+++ b/FormsGallery/FormsGallery/FormsGallery/ActivityIndicatorDemoPage.cs
@@ -10,7 +10,7 @@ namespace FormsGallery
             Label header = new Label
             {
                 Text = "ActivityIndicator",
-                Font = Font.BoldSystemFontOfSize(40),
+                Font = Font.SystemFontOfSize(40, FontAttributes.Bold),
                 HorizontalOptions = LayoutOptions.Center
             };
 

--- a/FormsGallery/FormsGallery/FormsGallery/BoxViewDemoPage.cs
+++ b/FormsGallery/FormsGallery/FormsGallery/BoxViewDemoPage.cs
@@ -10,7 +10,7 @@ namespace FormsGallery
             Label header = new Label
             {
                 Text = "BoxView",
-                Font = Font.BoldSystemFontOfSize(50),
+                Font = Font.SystemFontOfSize(50, FontAttributes.Bold),
                 HorizontalOptions = LayoutOptions.Center
             };
 

--- a/FormsGallery/FormsGallery/FormsGallery/ButtonDemoPage.cs
+++ b/FormsGallery/FormsGallery/FormsGallery/ButtonDemoPage.cs
@@ -13,7 +13,7 @@ namespace FormsGallery
             Label header = new Label
             {
                 Text = "Button",
-                Font = Font.BoldSystemFontOfSize(50),
+                Font = Font.SystemFontOfSize(50, FontAttributes.Bold),
                 HorizontalOptions = LayoutOptions.Center
             };
 

--- a/FormsGallery/FormsGallery/FormsGallery/ContentPageDemoPage.cs
+++ b/FormsGallery/FormsGallery/FormsGallery/ContentPageDemoPage.cs
@@ -10,7 +10,7 @@ namespace FormsGallery
             Label header = new Label
             {
                 Text = "ContentPage",
-                Font = Font.BoldSystemFontOfSize(40),
+                Font = Font.SystemFontOfSize(40, FontAttributes.Bold),
                 HorizontalOptions = LayoutOptions.Center
             };
 

--- a/FormsGallery/FormsGallery/FormsGallery/ContentViewDemoPage.cs
+++ b/FormsGallery/FormsGallery/FormsGallery/ContentViewDemoPage.cs
@@ -10,7 +10,7 @@ namespace FormsGallery
             Label header = new Label
             {
                 Text = "ContentView",
-                Font = Font.BoldSystemFontOfSize(50),
+                Font = Font.SystemFontOfSize(50, FontAttributes.Bold),
                 HorizontalOptions = LayoutOptions.Center
             };
 

--- a/FormsGallery/FormsGallery/FormsGallery/DatePickerDemoPage.cs
+++ b/FormsGallery/FormsGallery/FormsGallery/DatePickerDemoPage.cs
@@ -10,7 +10,7 @@ namespace FormsGallery
             Label header = new Label
             {
                 Text = "DatePicker",
-                Font = Font.BoldSystemFontOfSize(50),
+                Font = Font.SystemFontOfSize(50, FontAttributes.Bold),
                 HorizontalOptions = LayoutOptions.Center
             };
 

--- a/FormsGallery/FormsGallery/FormsGallery/EditorDemoPage.cs
+++ b/FormsGallery/FormsGallery/FormsGallery/EditorDemoPage.cs
@@ -10,7 +10,7 @@ namespace FormsGallery
             Label header = new Label
             {
                 Text = "Editor",
-                Font = Font.BoldSystemFontOfSize(50),
+                Font = Font.SystemFontOfSize(50, FontAttributes.Bold),
                 HorizontalOptions = LayoutOptions.Center
             };
 

--- a/FormsGallery/FormsGallery/FormsGallery/EntryCellDemoPage.cs
+++ b/FormsGallery/FormsGallery/FormsGallery/EntryCellDemoPage.cs
@@ -10,7 +10,7 @@ namespace FormsGallery
             Label header = new Label
             {
                 Text = "EntryCell",
-                Font = Font.BoldSystemFontOfSize(50),
+                Font = Font.SystemFontOfSize(50, FontAttributes.Bold),
                 HorizontalOptions = LayoutOptions.Center
             };
 

--- a/FormsGallery/FormsGallery/FormsGallery/EntryDemoPage.cs
+++ b/FormsGallery/FormsGallery/FormsGallery/EntryDemoPage.cs
@@ -10,7 +10,7 @@ namespace FormsGallery
             Label header = new Label
             {
                 Text = "Entry",
-                Font = Font.BoldSystemFontOfSize(50),
+                Font = Font.SystemFontOfSize(50, FontAttributes.Bold),
                 HorizontalOptions = LayoutOptions.Center
             };
 

--- a/FormsGallery/FormsGallery/FormsGallery/FrameDemoPage.cs
+++ b/FormsGallery/FormsGallery/FormsGallery/FrameDemoPage.cs
@@ -10,7 +10,7 @@ namespace FormsGallery
             Label header = new Label
             {
                 Text = "Frame",
-                Font = Font.BoldSystemFontOfSize(50),
+                Font = Font.SystemFontOfSize(50, FontAttributes.Bold),
                 HorizontalOptions = LayoutOptions.Center
             };
 

--- a/FormsGallery/FormsGallery/FormsGallery/GridDemoPage.cs
+++ b/FormsGallery/FormsGallery/FormsGallery/GridDemoPage.cs
@@ -28,7 +28,7 @@ namespace FormsGallery
             grid.Children.Add(new Label
                 {
                     Text = "Grid",
-                    Font = Font.BoldSystemFontOfSize(50),
+                    Font = Font.SystemFontOfSize(50, FontAttributes.Bold),
                     HorizontalOptions = LayoutOptions.Center
                 }, 0, 3, 0, 1);
 

--- a/FormsGallery/FormsGallery/FormsGallery/ImageCellDemoPage.cs
+++ b/FormsGallery/FormsGallery/FormsGallery/ImageCellDemoPage.cs
@@ -10,7 +10,7 @@ namespace FormsGallery
             Label header = new Label
             {
                 Text = "ImageCell",
-                Font = Font.BoldSystemFontOfSize(50),
+                Font = Font.SystemFontOfSize(50, FontAttributes.Bold),
                 HorizontalOptions = LayoutOptions.Center
             };
 

--- a/FormsGallery/FormsGallery/FormsGallery/ImageDemoPage.cs
+++ b/FormsGallery/FormsGallery/FormsGallery/ImageDemoPage.cs
@@ -10,7 +10,7 @@ namespace FormsGallery
             Label header = new Label
             {
                 Text = "Image",
-                Font = Font.BoldSystemFontOfSize(50),
+                Font = Font.SystemFontOfSize(50, FontAttributes.Bold),
                 HorizontalOptions = LayoutOptions.Center
             };
 

--- a/FormsGallery/FormsGallery/FormsGallery/LabelDemoPage.cs
+++ b/FormsGallery/FormsGallery/FormsGallery/LabelDemoPage.cs
@@ -10,7 +10,7 @@ namespace FormsGallery
             Label header = new Label
             {
                 Text = "Label",
-                Font = Font.BoldSystemFontOfSize(50),
+                Font = Font.SystemFontOfSize(50, FontAttributes.Bold),
                 HorizontalOptions = LayoutOptions.Center
             };
 

--- a/FormsGallery/FormsGallery/FormsGallery/ListViewDemoPage.cs
+++ b/FormsGallery/FormsGallery/FormsGallery/ListViewDemoPage.cs
@@ -27,7 +27,7 @@ namespace FormsGallery
             Label header = new Label
             {
                 Text = "ListView",
-                Font = Font.BoldSystemFontOfSize(50),
+                Font = Font.SystemFontOfSize(50, FontAttributes.Bold),
                 HorizontalOptions = LayoutOptions.Center
             };
 

--- a/FormsGallery/FormsGallery/FormsGallery/MapDemoPage.cs
+++ b/FormsGallery/FormsGallery/FormsGallery/MapDemoPage.cs
@@ -23,7 +23,7 @@ namespace FormsGallery
             Label header = new Label
             {
                 Text = "Map",
-                Font = Font.BoldSystemFontOfSize(50),
+                Font = Font.SystemFontOfSize(50, FontAttributes.Bold),
                 HorizontalOptions = LayoutOptions.Center
             };
 

--- a/FormsGallery/FormsGallery/FormsGallery/MasterDetailPageDemoPage.cs
+++ b/FormsGallery/FormsGallery/FormsGallery/MasterDetailPageDemoPage.cs
@@ -10,7 +10,7 @@ namespace FormsGallery
             Label header = new Label
             {
                 Text = "MasterDetailPage",
-                Font = Font.BoldSystemFontOfSize(30),
+                Font = Font.SystemFontOfSize(30, FontAttributes.Bold),
                 HorizontalOptions = LayoutOptions.Center
             };
 

--- a/FormsGallery/FormsGallery/FormsGallery/NavigationPageDemoPage.cs
+++ b/FormsGallery/FormsGallery/FormsGallery/NavigationPageDemoPage.cs
@@ -13,7 +13,7 @@ namespace FormsGallery
             Label header = new Label
             {
                 Text = "NavigationPage",
-                Font = Font.BoldSystemFontOfSize(40),
+                Font = Font.SystemFontOfSize(40, FontAttributes.Bold),
                 HorizontalOptions = LayoutOptions.Center
             };
 

--- a/FormsGallery/FormsGallery/FormsGallery/PickerDemoPage.cs
+++ b/FormsGallery/FormsGallery/FormsGallery/PickerDemoPage.cs
@@ -24,7 +24,7 @@ namespace FormsGallery
             Label header = new Label
             {
                 Text = "Picker",
-                Font = Font.BoldSystemFontOfSize(50),
+                Font = Font.SystemFontOfSize(50, FontAttributes.Bold),
                 HorizontalOptions = LayoutOptions.Center
             };
 

--- a/FormsGallery/FormsGallery/FormsGallery/ProgressBarDemoPage.cs
+++ b/FormsGallery/FormsGallery/FormsGallery/ProgressBarDemoPage.cs
@@ -13,7 +13,7 @@ namespace FormsGallery
             Label header = new Label
             {
                 Text = "ProgressBar",
-                Font = Font.BoldSystemFontOfSize(50),
+                Font = Font.SystemFontOfSize(50, FontAttributes.Bold),
                 HorizontalOptions = LayoutOptions.Center
             };
 

--- a/FormsGallery/FormsGallery/FormsGallery/RelativeLayoutDemoPage.cs
+++ b/FormsGallery/FormsGallery/FormsGallery/RelativeLayoutDemoPage.cs
@@ -10,7 +10,7 @@ namespace FormsGallery
             Label header = new Label
             {
                 Text = "RelativeLayout",
-                Font = Font.BoldSystemFontOfSize(40),
+                Font = Font.SystemFontOfSize(40, FontAttributes.Bold),
                 XAlign = TextAlignment.Center
             };
 

--- a/FormsGallery/FormsGallery/FormsGallery/ScrollViewDemoPage.cs
+++ b/FormsGallery/FormsGallery/FormsGallery/ScrollViewDemoPage.cs
@@ -10,7 +10,7 @@ namespace FormsGallery
             Label header = new Label
             {
                 Text = "ScrollView",
-                Font = Font.BoldSystemFontOfSize(50),
+                Font = Font.SystemFontOfSize(50, FontAttributes.Bold),
                 HorizontalOptions = LayoutOptions.Center
             };
 

--- a/FormsGallery/FormsGallery/FormsGallery/SearchBarDemoPage.cs
+++ b/FormsGallery/FormsGallery/FormsGallery/SearchBarDemoPage.cs
@@ -15,7 +15,7 @@ namespace FormsGallery
             Label header = new Label
             {
                 Text = "SearchBar",
-                Font = Font.BoldSystemFontOfSize(50),
+                Font = Font.SystemFontOfSize(50, FontAttributes.Bold),
                 HorizontalOptions = LayoutOptions.Center
             };
 

--- a/FormsGallery/FormsGallery/FormsGallery/SliderDemoPage.cs
+++ b/FormsGallery/FormsGallery/FormsGallery/SliderDemoPage.cs
@@ -12,7 +12,7 @@ namespace FormsGallery
             Label header = new Label
             {
                 Text = "Slider",
-                Font = Font.BoldSystemFontOfSize(50),
+                Font = Font.SystemFontOfSize(50, FontAttributes.Bold),
                 HorizontalOptions = LayoutOptions.Center
             };
 

--- a/FormsGallery/FormsGallery/FormsGallery/StackLayoutDemoPage.cs
+++ b/FormsGallery/FormsGallery/FormsGallery/StackLayoutDemoPage.cs
@@ -10,7 +10,7 @@ namespace FormsGallery
             Label header = new Label
             {
                 Text = "StackLayout",
-                Font = Font.BoldSystemFontOfSize(50),
+                Font = Font.SystemFontOfSize(50, FontAttributes.Bold),
                 HorizontalOptions = LayoutOptions.Center
             };
 

--- a/FormsGallery/FormsGallery/FormsGallery/StepperDemoPage.cs
+++ b/FormsGallery/FormsGallery/FormsGallery/StepperDemoPage.cs
@@ -12,7 +12,7 @@ namespace FormsGallery
             Label header = new Label
             {
                 Text = "Stepper",
-                Font = Font.BoldSystemFontOfSize(50),
+                Font = Font.SystemFontOfSize(50, FontAttributes.Bold),
                 HorizontalOptions = LayoutOptions.Center
             };
 

--- a/FormsGallery/FormsGallery/FormsGallery/SwitchCellDemoPage.cs
+++ b/FormsGallery/FormsGallery/FormsGallery/SwitchCellDemoPage.cs
@@ -10,7 +10,7 @@ namespace FormsGallery
             Label header = new Label
             {
                 Text = "SwitchCell",
-                Font = Font.BoldSystemFontOfSize(50),
+                Font = Font.SystemFontOfSize(50, FontAttributes.Bold),
                 HorizontalOptions = LayoutOptions.Center
             };
 

--- a/FormsGallery/FormsGallery/FormsGallery/SwitchDemoPage.cs
+++ b/FormsGallery/FormsGallery/FormsGallery/SwitchDemoPage.cs
@@ -12,7 +12,7 @@ namespace FormsGallery
             Label header = new Label
             {
                 Text = "Switch",
-                Font = Font.BoldSystemFontOfSize(50),
+                Font = Font.SystemFontOfSize(50, FontAttributes.Bold),
                 HorizontalOptions = LayoutOptions.Center
             };
 

--- a/FormsGallery/FormsGallery/FormsGallery/TableViewFormDemoPage.cs
+++ b/FormsGallery/FormsGallery/FormsGallery/TableViewFormDemoPage.cs
@@ -10,7 +10,7 @@ namespace FormsGallery
             Label header = new Label
             {
                 Text = "TableView for a form",
-                Font = Font.BoldSystemFontOfSize(30),
+                Font = Font.SystemFontOfSize(30, FontAttributes.Bold),
                 HorizontalOptions = LayoutOptions.Center
             };
 

--- a/FormsGallery/FormsGallery/FormsGallery/TableViewMenuDemoPage.cs
+++ b/FormsGallery/FormsGallery/FormsGallery/TableViewMenuDemoPage.cs
@@ -10,7 +10,7 @@ namespace FormsGallery
             Label header = new Label
             {
                 Text = "TableView for a menu",
-                Font = Font.BoldSystemFontOfSize(30),
+                Font = Font.SystemFontOfSize(30, FontAttributes.Bold),
                 HorizontalOptions = LayoutOptions.Center
             };
 

--- a/FormsGallery/FormsGallery/FormsGallery/TextCellDemoPage.cs
+++ b/FormsGallery/FormsGallery/FormsGallery/TextCellDemoPage.cs
@@ -10,7 +10,7 @@ namespace FormsGallery
             Label header = new Label
             {
                 Text = "TextCell",
-                Font = Font.BoldSystemFontOfSize(50),
+                Font = Font.SystemFontOfSize(50, FontAttributes.Bold),
                 HorizontalOptions = LayoutOptions.Center
             };
 

--- a/FormsGallery/FormsGallery/FormsGallery/TimePickerDemoPage.cs
+++ b/FormsGallery/FormsGallery/FormsGallery/TimePickerDemoPage.cs
@@ -10,7 +10,7 @@ namespace FormsGallery
             Label header = new Label
             {
                 Text = "TimePicker",
-                Font = Font.BoldSystemFontOfSize(50),
+                Font = Font.SystemFontOfSize(50, FontAttributes.Bold),
                 HorizontalOptions = LayoutOptions.Center
             };
 

--- a/FormsGallery/FormsGallery/FormsGallery/WebViewDemoPage.cs
+++ b/FormsGallery/FormsGallery/FormsGallery/WebViewDemoPage.cs
@@ -10,7 +10,7 @@ namespace FormsGallery
             Label header = new Label
             {
                 Text = "WebView",
-                Font = Font.BoldSystemFontOfSize(50),
+                Font = Font.SystemFontOfSize(50, FontAttributes.Bold),
                 HorizontalOptions = LayoutOptions.Center
             };
 


### PR DESCRIPTION
The FormsGallery had a bunch of warnings. I fixed them.

![fix warning](https://cloud.githubusercontent.com/assets/1173057/3710736/cc2f2cfa-14a6-11e4-9a98-bcd1c03de2ec.png)

>  Warning CS0618: `Xamarin.Forms.Font.BoldSystemFontOfSize(double)' is obsolete: `BoldSystemFontOfSize is obsolete, please use SystemFontOfSize (double, FontAttributes)' (CS0618) (FormsGallery)