### PR TITLE
Use MessagingCenter to allow each platform to control how the navigation happens

### DIFF
--- a/Forms2Native/Forms2Native.Android/Forms2Native.Android.csproj
+++ b/Forms2Native/Forms2Native.Android/Forms2Native.Android.csproj
@@ -67,7 +67,6 @@
     <Compile Include="Resources\Resource.designer.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="MySecondPageRenderer.cs" />
-    <Compile Include="MyThirdPageRenderer.cs" />
     <Compile Include="MyThirdActivity.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/Forms2Native/Forms2Native.Android/MainActivity.cs
+++ b/Forms2Native/Forms2Native.Android/MainActivity.cs
@@ -1,11 +1,7 @@
-﻿using System;
-using Android.App;
-using Android.Content;
-using Android.Runtime;
-using Android.Views;
-using Android.Widget;
+﻿using Android.App;
 using Android.OS;
-using System.IO;
+
+using Xamarin.Forms;
 
 namespace Forms2Native
 {
@@ -19,11 +15,19 @@ namespace Forms2Native
 		{
 			base.OnCreate (bundle);
 
-			Xamarin.Forms.Forms.Init (this, bundle);
+			Forms.Init (this, bundle);
 
 			LoadApplication (new App ());
+
+			MessagingCenter.Subscribe<MyFirstPage, NativeNavigationArgs>(
+				this,
+				App.NativeNavigationMessage,
+				HandleNativeNavigationMessage);
+		}
+
+		private void HandleNativeNavigationMessage(MyFirstPage sender, NativeNavigationArgs args)
+		{
+			StartActivity(typeof(MyThirdActivity));
 		}
 	}
 }
-
-

--- a/Forms2Native/Forms2Native.WinPhone/MainPage.xaml.cs
+++ b/Forms2Native/Forms2Native.WinPhone/MainPage.xaml.cs
@@ -13,15 +13,25 @@ using Forms2Native;
 
 namespace Forms2Native.WinPhone
 {
-	public partial class MainPage : global::Xamarin.Forms.Platform.WinPhone.FormsApplicationPage
+    public partial class MainPage : global::Xamarin.Forms.Platform.WinPhone.FormsApplicationPage
     {
-        public MainPage()
+        public MainPage ()
         {
-            InitializeComponent();
+            InitializeComponent ();
 
-            Forms.Init();
-           
-			LoadApplication (new Forms2Native.App ());
+            Forms.Init ();
+
+            LoadApplication (new Forms2Native.App ());
+
+            MessagingCenter.Subscribe<MyFirstPage, NativeNavigationArgs> (
+	            this,
+	            App.NativeNavigationMessage,
+	            HandleNativeNavigationMessage);
+        }
+
+        private void HandleNativeNavigationMessage (MyFirstPage sender, NativeNavigationArgs args)
+        {
+            sender.Navigation.PushAsync (args.Page);
         }
     }
 }

--- a/Forms2Native/Forms2Native.iOS/AppDelegate.cs
+++ b/Forms2Native/Forms2Native.iOS/AppDelegate.cs
@@ -1,11 +1,7 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
 using Foundation;
 using UIKit;
 using Forms2Native;
 using Xamarin.Forms;
-using System.IO;
 using Xamarin.Forms.Platform.iOS;
 
 namespace Forms2Native
@@ -27,7 +23,18 @@ namespace Forms2Native
 		{
 			Forms.Init ();
 			LoadApplication (new App ());
+
+			MessagingCenter.Subscribe<MyFirstPage, NativeNavigationArgs>(
+				this,
+				App.NativeNavigationMessage,
+				HandleNativeNavigationMessage);
+			
 			return base.FinishedLaunching (app, options);
+		}
+
+		private void HandleNativeNavigationMessage(MyFirstPage sender, NativeNavigationArgs args)
+		{
+			sender.Navigation.PushAsync(args.Page);
 		}
 	}
 }

--- a/Forms2Native/Forms2Native/App.cs
+++ b/Forms2Native/Forms2Native/App.cs
@@ -5,6 +5,8 @@ namespace Forms2Native
 {
 	public class App : Application
 	{
+		public const string NativeNavigationMessage = "Forms2Native.NativeNavigationMessage";
+
 		public App ()
 		{
 			var mainNav = new NavigationPage (new MyFirstPage ()); 

--- a/Forms2Native/Forms2Native/Forms2Native.csproj
+++ b/Forms2Native/Forms2Native/Forms2Native.csproj
@@ -6,7 +6,7 @@
     <ProjectGuid>{5F610EA1-9E35-4870-AE9B-5E18B4B4D5B8}</ProjectGuid>
     <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <OutputType>Library</OutputType>
-    <RootNamespace>QuickTodo</RootNamespace>
+    <RootNamespace>Forms2Native</RootNamespace>
     <AssemblyName>QuickTodo</AssemblyName>
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <TargetFrameworkProfile>Profile78</TargetFrameworkProfile>
@@ -36,6 +36,7 @@
     <Compile Include="MyFirstPage.cs" />
     <Compile Include="MySecondPage.cs" />
     <Compile Include="MyThirdPage.cs" />
+    <Compile Include="NativeNavigationArgs.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath32)\Microsoft\Portable\$(TargetFrameworkVersion)\Microsoft.Portable.CSharp.targets" />
   <ItemGroup>

--- a/Forms2Native/Forms2Native/MyFirstPage.cs
+++ b/Forms2Native/Forms2Native/MyFirstPage.cs
@@ -29,7 +29,7 @@ namespace Forms2Native
 			button1.Clicked += (s, e) => Navigation.PushAsync (new MySecondPage ());
 
 			button2 = new Button { Text = GetNativeTitle() };
-			button2.Clicked += (s, e) => Navigation.PushAsync (new MyThirdPage ());
+			button2.Clicked += (s, e) => MessagingCenter.Send(this, App.NativeNavigationMessage, new NativeNavigationArgs(new MyThirdPage()));
 
 			Content = new StackLayout {
 				Spacing = 10,

--- a/Forms2Native/Forms2Native/NativeNavigationArgs.cs
+++ b/Forms2Native/Forms2Native/NativeNavigationArgs.cs
@@ -1,0 +1,15 @@
+﻿using Xamarin.Forms;
+
+namespace Forms2Native
+{
+	public class NativeNavigationArgs
+	{
+		public Page Page { get; private set; }
+
+		public NativeNavigationArgs(Page page)
+		{
+			Page = page;
+		}
+	}
+}
+


### PR DESCRIPTION
Android needs to use StartActivity without a custom renderer to make the back navigation work properly.

With the current implementation on Android you go to the third page, and then when you press back you end up on a blank third page. You have to press back again to go back to the first page.

A better approach is to use MessageCenter to allow each platform to decide how to do the navigation. I chose to make iOS and Windows to the same thing that was done before. On Android instead of pushing a page on the navigation stack it just calls StartActivity (directly from MainActivity), which allows the back button to do the right thing.

I have seen multiple people get confused about this on the forums. This is a much better example of how to do this. 