### PR TITLE
Avoiding ambiguous reference that will occur after upgrade to Forms 2.1

### DIFF
--- a/Native2Forms/Native2Forms.Android/MainActivity.cs
+++ b/Native2Forms/Native2Forms.Android/MainActivity.cs
@@ -7,7 +7,6 @@ using Android.Widget;
 using Android.OS;
 using System.IO;
 using Xamarin.Forms.Platform.Android;
-using Native2Forms.Android;
 
 namespace Native2Forms
 {
@@ -23,9 +22,9 @@ namespace Native2Forms
 		{
 			base.OnCreate (bundle);
 
-			SetContentView(Resource.Layout.Main);
+			SetContentView(Native2Forms.Android.Resource.Layout.Main);
 
-			button = FindViewById<Button> (Resource.Id.button);
+			button = FindViewById<Button> (Native2Forms.Android.Resource.Id.button);
 
 			button.Click += (sender, e) => {
 				// this is our Xamarin.Forms screen


### PR DESCRIPTION
This avoids an ambiguous reference between 'Xamarin.Forms.Platform.Android.Resource' and 'Native2Forms.Android.Resource' that will occur when Forms is upgraded to 2.1. 

See https://bugzilla.xamarin.com/show_bug.cgi?id=38313