### PR TITLE
[ImageResizer] Fix "unsupported parameter combination" error in iOS i…

### DIFF
--- a/XamFormsImageResize/XamFormsImageResize/ImageResizer.cs
+++ b/XamFormsImageResize/XamFormsImageResize/ImageResizer.cs
@@ -47,7 +47,7 @@ namespace XamFormsImageResize
 			//create a 24bit RGB image
 			using (CGBitmapContext context = new CGBitmapContext (IntPtr.Zero,
 				                                 (int)width, (int)height, 8,
-				                                 (int)(4 * width), CGColorSpace.CreateDeviceRGB (),
+				                                 (int)(4 * (int)width), CGColorSpace.CreateDeviceRGB (),
 				                                 CGImageAlphaInfo.PremultipliedFirst)) {
 
 				RectangleF imageRect = new RectangleF (0, 0, width, height);


### PR DESCRIPTION
…mplementation

The error occurs if a wrong value for `bytesPerRow` is passed to the `CGBitmapContext` function and leads to a crash.

The fixed code calculates the correct value by casting `width` to `int` before multiplying it.