### PR TITLE
Ambiguity in System.Reflection GetInfo()

### DIFF
--- a/WorkingWithFiles/PCL/WorkingWithFiles/LoadResourceJson.cs
+++ b/WorkingWithFiles/PCL/WorkingWithFiles/LoadResourceJson.cs
@@ -12,7 +12,8 @@ namespace WorkingWithFiles
 		public LoadResourceJson()
 		{
 			#region How to load an Json file embedded resource
-			var assembly = typeof(LoadResourceText).GetTypeInfo().Assembly;
+			var assembly = IntrospectionExtensions.GetTypeInfo(typeof(LoadResourceText)).Assembly;
+
 			Stream stream = assembly.GetManifestResourceStream("WorkingWithFiles.PCLJsonResource.json");
 
 			Earthquake[] earthquakes;

--- a/WorkingWithFiles/PCL/WorkingWithFiles/LoadResourceText.cs
+++ b/WorkingWithFiles/PCL/WorkingWithFiles/LoadResourceText.cs
@@ -12,7 +12,7 @@ namespace WorkingWithFiles
 			var editor = new Label { Text = "loading...", HeightRequest = 300};
 
 			#region How to load a text file embedded resource
-			var assembly = typeof(LoadResourceText).GetTypeInfo().Assembly;
+			var assembly = IntrospectionExtensions.GetTypeInfo(typeof(LoadResourceText)).Assembly;
 			Stream stream = assembly.GetManifestResourceStream("WorkingWithFiles.PCLTextResource.txt");
 
 			string text = "";

--- a/WorkingWithFiles/PCL/WorkingWithFiles/LoadResourceXml.cs
+++ b/WorkingWithFiles/PCL/WorkingWithFiles/LoadResourceXml.cs
@@ -12,7 +12,7 @@ namespace WorkingWithFiles
 		public LoadResourceXml ()
 		{
 			#region How to load an XML file embedded resource
-			var assembly = typeof(LoadResourceText).GetTypeInfo().Assembly;
+			var assembly = IntrospectionExtensions.GetTypeInfo(typeof(LoadResourceText)).Assembly;
 			Stream stream = assembly.GetManifestResourceStream("WorkingWithFiles.PCLXmlResource.xml");
 
 			List<Monkey> monkeys;


### PR DESCRIPTION
GetInfo is now called specifically from InstrospectionExtensions, avoiding ambiguity with other reflection extensions (e.g., TypeExtensions GetInfo).
