### PR TITLE
Fix issue where the custom pin was not showing on iOS

### DIFF
--- a/CustomRenderers/Map/iOS/CustomMKPinAnnotationView.cs
+++ b/CustomRenderers/Map/iOS/CustomMKPinAnnotationView.cs
@@ -2,7 +2,7 @@
 
 namespace CustomRenderer.iOS
 {
-	public class CustomMKPinAnnotationView : MKPinAnnotationView
+	public class CustomMKPinAnnotationView : MKAnnotationView
 	{
 		public string Id { get; set; }
 


### PR DESCRIPTION
The sample was expecting the custom image defined in pin.png to show on the map on iOS but it was not working. This is because the base class the sample was using does not support a custom image.