### PR TITLE
Removed unnecessary SQLitePCL.raw reference in iOS Project

### DIFF
--- a/Todo/PCL/Todo.iOS/Todo.iOS.csproj
+++ b/Todo/PCL/Todo.iOS/Todo.iOS.csproj
@@ -103,9 +103,6 @@
     <Reference Include="SQLitePCL.batteries">
       <HintPath>..\packages\SQLitePCL.bundle_green.0.9.3\lib\portable-net45+netcore45+wpa81+wp8+MonoAndroid10+MonoTouch10+Xamarin.iOS10\SQLitePCL.batteries.dll</HintPath>
     </Reference>
-    <Reference Include="SQLitePCL.raw">
-      <HintPath>..\packages\SQLitePCL.raw.0.9.3\lib\Xamarin.iOS10\SQLitePCL.raw.dll</HintPath>
-    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="Xamarin.Forms.Core">


### PR DESCRIPTION
Reference to that resource was already being inherited from parent. For some reason it wasn't an issue in Xamarin Studio for MAC but was throwing an error in Visual Studio for Windows. After the change, it works in both platforms.

It is a fix for the bug [https://bugzilla.xamarin.com/show_bug.cgi?id=45068](https://bugzilla.xamarin.com/show_bug.cgi?id=45068)