### PR TITLE
Remove obsolete BaseUrlWebView class

### DIFF
--- a/WorkingWithWebview/WorkingWithWebview/LocalHtmlBaseUrl.cs
+++ b/WorkingWithWebview/WorkingWithWebview/LocalHtmlBaseUrl.cs
@@ -6,14 +6,11 @@ namespace WorkingWithWebview
 
 	public interface IBaseUrl { string Get(); }
 
-	// required temporarily for iOS, due to BaseUrl bug
-	public class BaseUrlWebView : WebView { }
-
 	public class LocalHtmlBaseUrl : ContentPage
 	{
 		public LocalHtmlBaseUrl ()
 		{
-			var browser = new BaseUrlWebView (); // temporarily use this so we can custom-render in iOS
+			var browser = new WebView ();
 
 			var htmlSource = new HtmlWebViewSource ();
 


### PR DESCRIPTION
It seems like there was a BaseUrl bug back in a day, but it was resolved. 
Simple clean up to reduce confusion. 
Also the docs (https://developer.xamarin.com/guides/xamarin-forms/working-with/webview/) still mention this bug. 
