### PR TITLE
Workaround for UWP b#53215 in MasterDetailPage sample

### DIFF
--- a/Navigation/MasterDetailPage/MasterDetailPageNavigation/MainPage.xaml.cs
+++ b/Navigation/MasterDetailPage/MasterDetailPageNavigation/MainPage.xaml.cs
@@ -19,9 +19,16 @@ namespace MasterDetailPageNavigation
 		void OnItemSelected (object sender, SelectedItemChangedEventArgs e)
 		{
 			var item = e.SelectedItem as MasterPageItem;
-			if (item != null) {
-				Detail = new NavigationPage ((Page)Activator.CreateInstance (item.TargetType));
+			if (item != null)
+			{
+				Detail = new NavigationPage((Page)Activator.CreateInstance(item.TargetType));
 				masterPage.ListView.SelectedItem = null;
+
+				// Workaround for bug #53215 until https://github.com/xamarin/Xamarin.Forms/pull/707
+				// is available in a stable release
+				if (Device.OS == TargetPlatform.Windows && Device.Idiom == TargetIdiom.Desktop)
+					return;
+
 				IsPresented = false;
 			}
 		}


### PR DESCRIPTION
There is currently [a bug on desktop UWP](https://bugzilla.xamarin.com/show_bug.cgi?id=53215) where the Master icon is not visible after hiding the Master page which prevents the user from opening it again. 

[A fix for the bug](https://github.com/xamarin/Xamarin.Forms/pull/707) has been merged, but is not yet available in a release. So in the meantime the workaround is to manually prevent `IsPresented = false` from being called after selecting an item.