### PR TITLE
Use a native Android activity in the Native2Forms example

### DIFF
--- a/Native2Forms/Native2Forms.Android/MainActivity.cs
+++ b/Native2Forms/Native2Forms.Android/MainActivity.cs
@@ -14,7 +14,7 @@ namespace Native2Forms
 	/// This is a native Android screen. It will open a Xamarin.Forms screen.
 	/// </summary>
 	[Activity (Label = "Native2Forms", MainLauncher = true)]
-	public class Activity1 : FormsApplicationActivity
+	public class Activity1 : Activity
 	{
 		Button button;
 
@@ -30,9 +30,6 @@ namespace Native2Forms
 				// this is our Xamarin.Forms screen
 				StartActivity(typeof(FormsActivity));
 			};
-
-			Xamarin.Forms.Forms.Init (this, bundle);
-			LoadApplication (new App ());
 		}
 	}
 }


### PR DESCRIPTION
The current Native2Forms Android example is using `FormsApplicationActivity` as the starting point for the Android example; it should be using a `Activity`.