### PR TITLE
Fix Crash - Cannot add multiple unique keys

### DIFF
--- a/SkiaSharpForms/SkiaSharpFormsDemos/SkiaSharpFormsDemos/SkiaSharpFormsDemos.iOS/TouchRecognizer.cs
+++ b/SkiaSharpForms/SkiaSharpFormsDemos/SkiaSharpFormsDemos/SkiaSharpFormsDemos.iOS/TouchRecognizer.cs
@@ -47,7 +47,10 @@ namespace TouchTracking.iOS
                 long id = touch.Handle.ToInt64();
                 FireEvent(this, id, TouchActionType.Pressed, touch, true);
 
-                idToTouchDictionary.Add(id, this);
+                if (!idToTouchDictionary.ContainsKey(id))
+                {
+                    idToTouchDictionary.Add(id, this);
+                }
             }
 
             // Save the setting of the Capture property


### PR DESCRIPTION
When clicking fast in the same area, the key of the touch might be the same.