### PR TITLE
Fix crash on Xamarin Live Player

### DIFF
--- a/WorkingWithListview/Android/WorkingWithListview.Android.csproj
+++ b/WorkingWithListview/Android/WorkingWithListview.Android.csproj
@@ -97,7 +97,6 @@
     <Compile Include="MainActivity.cs" />
     <Compile Include="Resources\Resource.designer.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
-    <Compile Include="ButtonRenderer.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="Resources\AboutResources.txt" />


### PR DESCRIPTION
Removed the custom renderer, they are not supported on XLP.
