### PR TITLE
[MonkeyApp] Change Constants so that the sample doesn't crash on startup

### DIFF
--- a/WebServices/AzureSearch/MonkeyApp/Constants.cs
+++ b/WebServices/AzureSearch/MonkeyApp/Constants.cs
@@ -2,8 +2,8 @@
 {
 	public static class Constants
 	{
-		public static readonly string SearchServiceName = "<INSERT_SEARCH_SERVICE_NAME_HERE>";
-		public static readonly string QueryApiKey = "<INSERT_QUERY_API_KEY_HERE>";
+		public static readonly string SearchServiceName = "INSERT_SEARCH_SERVICE_NAME_HERE";
+		public static readonly string QueryApiKey = "INSERT_QUERY_API_KEY_HERE";
 		public static readonly string Index = "monkeys";
 	}
 }


### PR DESCRIPTION
Looks like the Azure.Search now checks the URLs for invalid
characters. Changing the `Constants` strings make it start at least. I
guess the crash at the sample start is not intended.

Fixes #559641