### PR TITLE
[XI] fixed crush when capturing, "CustomRenderers" project

### DIFF
--- a/CustomRenderers/ContentPage/iOS/Info.plist
+++ b/CustomRenderers/ContentPage/iOS/Info.plist
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
@@ -11,7 +11,7 @@
 	<key>CFBundleVersion</key>
 	<string>1.0</string>
 	<key>LSRequiresIPhoneOS</key>
-	<true />
+	<true/>
 	<key>MinimumOSVersion</key>
 	<string>9.0</string>
 	<key>UIDeviceFamily</key>
@@ -61,5 +61,7 @@
 	<string>CustomRenderer</string>
 	<key>NSCameraUsageDescription</key>
 	<string>This app is using the camera</string>
+	<key>NSPhotoLibraryAddUsageDescription</key>
+	<string>This app is saving photo to the library</string>
 </dict>
 </plist>


### PR DESCRIPTION
- fixed crush when capturing (info.plist)
- fixed [bugzilla bug](https://github.com/xamarin/xamarin-forms-samples/commits/master) - additional disposing
- fixed screen size - not it depends on `View.Bounds.Width`
- updated obsolete `DefaultDeviceWithMediaType` method