### PR TITLE
Added code to set the UWP endpoint to the value of Constants.SoapUrl

### DIFF
--- a/WebServices/TodoASMX/UWP/SoapService.cs
+++ b/WebServices/TodoASMX/UWP/SoapService.cs
@@ -14,6 +14,7 @@ namespace TodoASMX.UWP
         public SoapService()
         {
             todoService = new ASMXService.TodoASMXServiceSoapClient();
+            todoService.Endpoint.Address = new System.ServiceModel.EndpointAddress(Constants.SoapUrl);
         }
 
         ASMXService.TodoItem ToASMXServiceTodoItem(TodoItem item)


### PR DESCRIPTION
### Description of Change

https://github.com/xamarin/xamarin-forms-samples/tree/master/WebServices/TodoASMX

The UWP project wasn't changing the endpoint based on the value of 
```c#
Constants.SoapUrl
```

### Pull Request Checklist

- [X] Rebased on top of master at time of the pull request.
- [X] Changes adhere to coding standard in the sample.
- [ ] Consolidated NuGet packages across all projects in the sample (when changing existing package versions).
- [X] Tested changes on the appropriate platforms (all platforms if changing the library code).
