### PR TITLE
NSMicrophoneUsageDescription required otherwise app crashes

### DIFF
--- a/WebServices/TodoCognitiveServices/iOS/Info.plist
+++ b/WebServices/TodoCognitiveServices/iOS/Info.plist
@@ -44,5 +44,7 @@
 	<string>Assets.xcassets/AppIcon.appiconset</string>
 	<key>NSPhotoLibraryUsageDescription</key>
 	<string>This application needs access to the photo library.</string>
+  <key>NSMicrophoneUsageDescription</key>
+	<string>This app needs access to the mic to rec sounds.</string> 
 </dict>
 </plist>


### PR DESCRIPTION
### Description of Change

https://github.com/xamarin/xamarin-forms-samples/tree/master/WebServices/TodoCognitiveServices
NSMicrophoneUsageDescription has to be set to something otherwise app crashes when trying to record


### Pull Request Checklist

<!-- Please complete -->

- [X] Rebased on top of master at time of the pull request.
- [X] Changes adhere to coding standard in the sample.
- [X] Consolidated NuGet packages across all projects in the sample (when changing existing package versions).
- [X] Tested changes on the appropriate platforms (all platforms if changing the library code).
