### PR TITLE
fix json.net not found error

### DIFF
--- a/WebServices/TodoDocumentDBAuth/ResourceTokenBroker/ResourceTokenBroker/Web.config
+++ b/WebServices/TodoDocumentDBAuth/ResourceTokenBroker/ResourceTokenBroker/Web.config
@@ -55,7 +55,7 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Newtonsoft.Json" culture="neutral" publicKeyToken="30ad4fe6b2a6aeed" />
-        <bindingRedirect oldVersion="0.0.0.0-6.0.0.0" newVersion="6.0.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.0" newVersion="10.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="System.Web.Optimization" publicKeyToken="31bf3856ad364e35" />


### PR DESCRIPTION
### Description of Change
 ResourceTokenBroker project throws an exception about not being able to find version 6 of JSON.NET because version 10 is installed.  So the binding redirects need to reflect this

### Pull Request Checklist

<!-- Please complete -->

- [ ] Rebased on top of master at time of the pull request.
- [ ] Changes adhere to coding standard in the sample.
- [ ] Consolidated NuGet packages across all projects in the sample (when changing existing package versions).
- [ ] Tested changes on the appropriate platforms (all platforms if changing the library code).
