### PR TITLE
Disable <AndroidUseLatestPlatformSdk> for Circle-MapOverlay

### DIFF
--- a/CustomRenderers/Map/Circle/Droid/MapOverlay.Droid.csproj
+++ b/CustomRenderers/Map/Circle/Droid/MapOverlay.Droid.csproj
@@ -12,7 +12,7 @@
     <AndroidResgenClass>Resource</AndroidResgenClass>
     <AndroidResgenFile>Resources\Resource.designer.cs</AndroidResgenFile>
     <AndroidApplication>True</AndroidApplication>
-    <AndroidUseLatestPlatformSdk>True</AndroidUseLatestPlatformSdk>
+    <AndroidUseLatestPlatformSdk>False</AndroidUseLatestPlatformSdk>
     <AssemblyName>MapOverlay.Droid</AssemblyName>
     <AndroidManifest>Properties\AndroidManifest.xml</AndroidManifest>
     <TargetFrameworkVersion>v8.1</TargetFrameworkVersion>


### PR DESCRIPTION
### Description of Change

MapOverlay Xamarin.Forms sample fails to build with XA 8.3.99.10 (master) and VSM 7.6.0.695 (master)

Fix it by making sure we restore nuget packages for 8.1 specifically otherwise we end up trying to restore for 8.1.99

Original bug

Steps to reproduce:

1. Install VSMac 7.6 Preview (7.6 build 695) from master 
2. Install XA 8.3.99.10 from master build
3. Open Xamarin.Forms sample named MapOverlay from https://github.com/xamarin/xamarin-forms-samples/blob/master/CustomRenderers/Map/Circle/MapOverlay.sln
4. Build the sample

Expected: The build is successful
Actual: The Android project fails to build with 

/Library/Frameworks/Mono.framework/Versions/5.10.1/lib/mono/xbuild/Microsoft/NuGet/Microsoft.NuGet.targets(184,5): error : Your project is not referencing the "MonoAndroid,Version=v8.1" framework. Add a reference to "MonoAndroid,Version=v8.1" in the "frameworks" section of your project.json, and then re-run NuGet restore.

[NuGet restore output](http://xqa.blob.core.windows.net/gist/PackageConsole-Add-All-2492d24328b741cfa1739c3d3d2e3087.txt)

Please note that it tries to restore for 8.1.99

[Build Output in Diagnostic Mode](http://xqa.blob.core.windows.net/gist/log-eb18393005114affa96c95875dd5373d.txt)

[About VS (with versions of different products and API Levels installed)](http://xqa.blob.core.windows.net/gist/log-3d179cff1128442c820eae0619f4e546.txt)

[Screenshot of failure in VS for Mac](http://xqa.blob.core.windows.net/gist/017-Test-Failed.png-cc0b512ed5e14a099a2ac39ced4c3e72.png)

### Pull Request Checklist

<!-- Please complete -->

- [x] Rebased on top of master at time of the pull request.
- [x] Changes adhere to coding standard in the sample.
- [x] Consolidated NuGet packages across all projects in the sample (when changing existing package versions).
- [x] Tested changes on the appropriate platforms (all platforms if changing the library code).
