### PR TITLE
[XI] fixed `keychain-access-groups` value; "OAuthNativeFlow.iOS" project

### DIFF
--- a/WebServices/OAuthNativeFlow/iOS/Entitlements.plist
+++ b/WebServices/OAuthNativeFlow/iOS/Entitlements.plist
@@ -4,7 +4,7 @@
 <dict>
 	<key>keychain-access-groups</key>
 	<array>
-		<string>com.companyname.oauthnativeflow</string>
+		<string>$(AppIdentifierPrefix)com.xamarin.oauthnativeflow</string>
 	</array>
 </dict>
 </plist>


### PR DESCRIPTION
Updated `keychain-access-groups` value because the installation into the real device was failed. 

```
Installing application bundle 'com.xamarin.oauthnativeflow' on '{device-name}'
 ApplicationVerificationFailed: Failed to verify code signature of /private/var/installd/Library/Caches/com.apple.mobile.installd.staging/temp.aTf4Q6/extracted/OAuthNativeFlow.iOS.app : 0xe8008016 (The executable was signed with invalid entitlements.)
error MT1006: Could not install the application '..../xamarin-forms-samples/WebServices/OAuthNativeFlow/iOS/bin/iPhone/Debug/OAuthNativeFlow.iOS.app' on the device '{device-name}': Your code signing/provisioning profiles are not correctly configured. Probably you have an entitlement not supported by your current provisioning profile, or your device is not part of the current provisioning profile. Please check the iOS Device Log for details (error: 0xe8008016).
EXIT CODE: 1
```