### PR TITLE
[CustomRenderer] Fixed 'MtouchArch' in 'Release' configuration

### DIFF
--- a/CustomRenderers/View/iOS/CustomRenderer.iOS.csproj
+++ b/CustomRenderers/View/iOS/CustomRenderer.iOS.csproj
@@ -33,7 +33,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <CodesignEntitlements>Entitlements.plist</CodesignEntitlements>
-    <MtouchArch>ARMv7, ARM64</MtouchArch>
+    <MtouchArch>ARM64</MtouchArch>
     <ConsolePause>false</ConsolePause>
     <CodesignKey>iPhone Developer</CodesignKey>
   </PropertyGroup>
@@ -43,7 +43,7 @@
     <OutputPath>bin\iPhoneSimulator\Release</OutputPath>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
-    <MtouchArch>i386, x86_64</MtouchArch>
+    <MtouchArch>x86_64</MtouchArch>
     <ConsolePause>false</ConsolePause>
     <MtouchLink>None</MtouchLink>
   </PropertyGroup>


### PR DESCRIPTION
Fixed:
```
MTOUCH : error MT0116: Invalid architecture: i386. 32-bit architectures are not supported when deployment target is 11 or later.
```