### PR TITLE
docs issue 962 - fix sliders

### DIFF
--- a/XamlSamples/XamlSamples/XamlSamples/HslColorScrollPage.xaml
+++ b/XamlSamples/XamlSamples/XamlSamples/HslColorScrollPage.xaml
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8" ?>
+<?xml version="1.0" encoding="utf-8" ?>
 <ContentPage xmlns="http://xamarin.com/schemas/2014/forms"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              xmlns:local="clr-namespace:XamlSamples;assembly=XamlSamples"
@@ -9,23 +9,26 @@
         <local:HslViewModel Color="Aqua" />
     </ContentPage.BindingContext>
 
-    <StackLayout Padding="10, 0">
+    <StackLayout Padding="10, 0, 10, 30">
         <BoxView Color="{Binding Color}"
                  VerticalOptions="FillAndExpand" />
 
         <Label Text="{Binding Hue, StringFormat='Hue = {0:F2}'}"
                HorizontalOptions="Center" />
 
-        <Slider Value="{Binding Hue, Mode=TwoWay}" />
+        <Slider Value="{Binding Hue, Mode=TwoWay}"
+                Margin="20,0,20,0" />
 
         <Label Text="{Binding Saturation, StringFormat='Saturation = {0:F2}'}"
                HorizontalOptions="Center" />
 
-        <Slider Value="{Binding Saturation, Mode=TwoWay}" />
+        <Slider Value="{Binding Saturation, Mode=TwoWay}" 
+                Margin="20,0,20,0" />
 
         <Label Text="{Binding Luminosity, StringFormat='Luminosity = {0:F2}'}"
                HorizontalOptions="Center" />
 
-        <Slider Value="{Binding Luminosity, Mode=TwoWay}" />
+        <Slider Value="{Binding Luminosity, Mode=TwoWay}" 
+                Margin="20,0,20,0" />
     </StackLayout>
 </ContentPage>

--- a/XamlSamples/XamlSamples/XamlSamples/SliderBindingsPage.xaml
+++ b/XamlSamples/XamlSamples/XamlSamples/SliderBindingsPage.xaml
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8" ?>
+<?xml version="1.0" encoding="utf-8" ?>
 <ContentPage xmlns="http://xamarin.com/schemas/2014/forms"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              x:Class="XamlSamples.SliderBindingsPage"
@@ -15,7 +15,8 @@
 
         <Slider x:Name="slider"
                 Maximum="360"
-                VerticalOptions="CenterAndExpand" />
+                VerticalOptions="CenterAndExpand"
+                Margin="20,0,20,0" />
 
         <Label BindingContext="{x:Reference slider}"
                Text="{Binding Value, StringFormat='The angle is {0:F0} degrees'}"

--- a/XamlSamples/XamlSamples/XamlSamples/SliderTransformsPage.xaml
+++ b/XamlSamples/XamlSamples/XamlSamples/SliderTransformsPage.xaml
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8" ?>
+<?xml version="1.0" encoding="utf-8" ?>
 <ContentPage xmlns="http://xamarin.com/schemas/2014/forms"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              x:Class="XamlSamples.SliderTransformsPage"
@@ -30,7 +30,8 @@
                 BindingContext="{x:Reference label}"
                 Grid.Row="1" Grid.Column="0"
                 Maximum="10"
-                Value="{Binding Scale, Mode=TwoWay}" />
+                Value="{Binding Scale, Mode=TwoWay}" 
+                Margin="20,0,0,0" />
 
         <Label BindingContext="{x:Reference scaleSlider}"
                Text="{Binding Value, StringFormat='Scale = {0:F1}'}"
@@ -42,7 +43,8 @@
                 BindingContext="{x:Reference label}"
                 Grid.Row="2" Grid.Column="0"
                 Maximum="360"
-                Value="{Binding Rotation, Mode=OneWayToSource}" />
+                Value="{Binding Rotation, Mode=OneWayToSource}" 
+                Margin="20,0,0,0" />
 
         <Label BindingContext="{x:Reference rotationSlider}"
                Text="{Binding Value, StringFormat='Rotation = {0:F0}'}"
@@ -54,7 +56,8 @@
                 BindingContext="{x:Reference label}"
                 Grid.Row="3" Grid.Column="0"
                 Maximum="360"
-                Value="{Binding RotationX, Mode=OneWayToSource}" />
+                Value="{Binding RotationX, Mode=OneWayToSource}"
+                Margin="20,0,0,0" />
 
         <Label BindingContext="{x:Reference rotationXSlider}"
                Text="{Binding Value, StringFormat='RotationX = {0:F0}'}"
@@ -66,7 +69,8 @@
                 BindingContext="{x:Reference label}"
                 Grid.Row="4" Grid.Column="0"
                 Maximum="360"
-                Value="{Binding RotationY, Mode=OneWayToSource}" />
+                Value="{Binding RotationY, Mode=OneWayToSource}"
+                Margin="20,0,0,0" />
 
         <Label BindingContext="{x:Reference rotationYSlider}"
                Text="{Binding Value, StringFormat='RotationY = {0:F0}'}"

--- a/XamlSamples/XamlSamples/XamlSamples/XamlPlusCodePage.xaml
+++ b/XamlSamples/XamlSamples/XamlSamples/XamlPlusCodePage.xaml
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8" ?>
+<?xml version="1.0" encoding="utf-8" ?>
 <ContentPage xmlns="http://xamarin.com/schemas/2014/forms"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              x:Class="XamlSamples.XamlPlusCodePage"
@@ -6,7 +6,8 @@
   
     <StackLayout>
         <Slider VerticalOptions="CenterAndExpand"
-                ValueChanged="OnSliderValueChanged" />
+                ValueChanged="OnSliderValueChanged" 
+                Margin="20,0,20,0" />
 
         <Label x:Name="valueLabel"
                Text="A simple Label"


### PR DESCRIPTION
### Description of Change

Add padding to sliders, to prevent the UINavigationController 'back' gesture being triggered.

Fixes https://github.com/MicrosoftDocs/xamarin-docs/issues/962

### Pull Request Checklist

<!-- Please complete -->

- [x] Rebased on top of master at time of the pull request.
- [x] Changes adhere to coding standard in the sample.
- [n/a] Consolidated NuGet packages across all projects in the sample (when changing existing package versions).
- [x] Tested changes on the appropriate platforms (all platforms if changing the library code).
