### PR TITLE
All samples use the Android native network stack

### DIFF
--- a/Advanced/DependencyResolution/DIContainerDemo/DIContainerDemo.Android/DIContainerDemo.Android.csproj
+++ b/Advanced/DependencyResolution/DIContainerDemo/DIContainerDemo.Android/DIContainerDemo.Android.csproj
@@ -16,6 +16,7 @@
     <MonoAndroidResourcePrefix>Resources</MonoAndroidResourcePrefix>
     <MonoAndroidAssetsPrefix>Assets</MonoAndroidAssetsPrefix>
     <TargetFrameworkVersion>v8.1</TargetFrameworkVersion>
+    <AndroidHttpClientHandlerType>Xamarin.Android.Net.AndroidClientHandler</AndroidHttpClientHandlerType>
     <NuGetPackageImportStamp></NuGetPackageImportStamp>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/Advanced/DependencyResolution/FactoriesDemo/FactoriesDemo.Android/FactoriesDemo.Android.csproj
+++ b/Advanced/DependencyResolution/FactoriesDemo/FactoriesDemo.Android/FactoriesDemo.Android.csproj
@@ -16,6 +16,7 @@
     <MonoAndroidResourcePrefix>Resources</MonoAndroidResourcePrefix>
     <MonoAndroidAssetsPrefix>Assets</MonoAndroidAssetsPrefix>
     <TargetFrameworkVersion>v8.1</TargetFrameworkVersion>
+    <AndroidHttpClientHandlerType>Xamarin.Android.Net.AndroidClientHandler</AndroidHttpClientHandlerType>
     <NuGetPackageImportStamp></NuGetPackageImportStamp>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/Behaviors/AttachedNumericValidationBehavior/WorkingWithBehaviors.Android/WorkingWithBehaviors.Android.csproj
+++ b/Behaviors/AttachedNumericValidationBehavior/WorkingWithBehaviors.Android/WorkingWithBehaviors.Android.csproj
@@ -15,6 +15,7 @@
     <AndroidManifest>Properties\AndroidManifest.xml</AndroidManifest>
     <TargetFrameworkVersion>v8.1</TargetFrameworkVersion>
     <JavaMaximumHeapSize>1G</JavaMaximumHeapSize>
+    <AndroidHttpClientHandlerType>Xamarin.Android.Net.AndroidClientHandler</AndroidHttpClientHandlerType>
     <NuGetPackageImportStamp />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/Behaviors/EffectBehavior/Droid/EffectsDemo.Droid.csproj
+++ b/Behaviors/EffectBehavior/Droid/EffectsDemo.Droid.csproj
@@ -15,6 +15,7 @@
     <AndroidApplication>True</AndroidApplication>
     <AssemblyName>EffectsDemo.Droid</AssemblyName>
     <TargetFrameworkVersion>v8.1</TargetFrameworkVersion>
+    <AndroidHttpClientHandlerType>Xamarin.Android.Net.AndroidClientHandler</AndroidHttpClientHandlerType>
     <NuGetPackageImportStamp />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/Behaviors/EventToCommandBehavior/Droid/EventToCommandBehavior.Droid.csproj
+++ b/Behaviors/EventToCommandBehavior/Droid/EventToCommandBehavior.Droid.csproj
@@ -15,6 +15,7 @@
     <AndroidApplication>True</AndroidApplication>
     <AssemblyName>EventToCommandBehavior.Droid</AssemblyName>
     <TargetFrameworkVersion>v8.1</TargetFrameworkVersion>
+    <AndroidHttpClientHandlerType>Xamarin.Android.Net.AndroidClientHandler</AndroidHttpClientHandlerType>
     <NuGetPackageImportStamp />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/Behaviors/NumericValidationBehavior/WorkingWithBehaviors.Android/WorkingWithBehaviors.Android.csproj
+++ b/Behaviors/NumericValidationBehavior/WorkingWithBehaviors.Android/WorkingWithBehaviors.Android.csproj
@@ -15,6 +15,7 @@
     <AndroidManifest>Properties\AndroidManifest.xml</AndroidManifest>
     <TargetFrameworkVersion>v8.1</TargetFrameworkVersion>
     <JavaMaximumHeapSize>1G</JavaMaximumHeapSize>
+    <AndroidHttpClientHandlerType>Xamarin.Android.Net.AndroidClientHandler</AndroidHttpClientHandlerType>
     <NuGetPackageImportStamp />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/Behaviors/NumericValidationBehaviorStyle/WorkingWithBehaviors.Android/WorkingWithBehaviors.Android.csproj
+++ b/Behaviors/NumericValidationBehaviorStyle/WorkingWithBehaviors.Android/WorkingWithBehaviors.Android.csproj
@@ -15,6 +15,7 @@
     <AndroidManifest>Properties\AndroidManifest.xml</AndroidManifest>
     <TargetFrameworkVersion>v8.1</TargetFrameworkVersion>
     <JavaMaximumHeapSize>1G</JavaMaximumHeapSize>
+    <AndroidHttpClientHandlerType>Xamarin.Android.Net.AndroidClientHandler</AndroidHttpClientHandlerType>
     <NuGetPackageImportStamp />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/BoxView/BasicBoxView/BasicBoxView/BasicBoxView.Android/BasicBoxView.Android.csproj
+++ b/BoxView/BasicBoxView/BasicBoxView/BasicBoxView.Android/BasicBoxView.Android.csproj
@@ -17,6 +17,7 @@
     <AndroidManifest>Properties\AndroidManifest.xml</AndroidManifest>
     <TargetFrameworkVersion>v8.1</TargetFrameworkVersion>
     <JavaMaximumHeapSize />
+    <AndroidHttpClientHandlerType>Xamarin.Android.Net.AndroidClientHandler</AndroidHttpClientHandlerType>
     <NuGetPackageImportStamp />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/BoxView/BoxViewClock/BoxViewClock/BoxViewClock.Android/BoxViewClock.Android.csproj
+++ b/BoxView/BoxViewClock/BoxViewClock/BoxViewClock.Android/BoxViewClock.Android.csproj
@@ -17,6 +17,7 @@
     <AndroidManifest>Properties\AndroidManifest.xml</AndroidManifest>
     <TargetFrameworkVersion>v8.1</TargetFrameworkVersion>
     <JavaMaximumHeapSize />
+    <AndroidHttpClientHandlerType>Xamarin.Android.Net.AndroidClientHandler</AndroidHttpClientHandlerType>
     <NuGetPackageImportStamp />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/BoxView/DotMatrixClock/DotMatrixClock/DotMatrixClock.Android/DotMatrixClock.Android.csproj
+++ b/BoxView/DotMatrixClock/DotMatrixClock/DotMatrixClock.Android/DotMatrixClock.Android.csproj
@@ -17,6 +17,7 @@
     <AndroidManifest>Properties\AndroidManifest.xml</AndroidManifest>
     <TargetFrameworkVersion>v8.1</TargetFrameworkVersion>
     <JavaMaximumHeapSize />
+    <AndroidHttpClientHandlerType>Xamarin.Android.Net.AndroidClientHandler</AndroidHttpClientHandlerType>
     <NuGetPackageImportStamp />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/BoxView/GameOfLife/GameOfLife/GameOfLife.Android/GameOfLife.Android.csproj
+++ b/BoxView/GameOfLife/GameOfLife/GameOfLife.Android/GameOfLife.Android.csproj
@@ -17,6 +17,7 @@
     <AndroidManifest>Properties\AndroidManifest.xml</AndroidManifest>
     <TargetFrameworkVersion>v8.1</TargetFrameworkVersion>
     <JavaMaximumHeapSize />
+    <AndroidHttpClientHandlerType>Xamarin.Android.Net.AndroidClientHandler</AndroidHttpClientHandlerType>
     <NuGetPackageImportStamp />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/BoxView/ListViewColors/ListViewColors/ListViewColors.Android/ListViewColors.Android.csproj
+++ b/BoxView/ListViewColors/ListViewColors/ListViewColors.Android/ListViewColors.Android.csproj
@@ -17,6 +17,7 @@
     <AndroidManifest>Properties\AndroidManifest.xml</AndroidManifest>
     <TargetFrameworkVersion>v8.1</TargetFrameworkVersion>
     <JavaMaximumHeapSize />
+    <AndroidHttpClientHandlerType>Xamarin.Android.Net.AndroidClientHandler</AndroidHttpClientHandlerType>
     <NuGetPackageImportStamp />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/BoxView/TextDecoration/TextDecoration/TextDecoration.Android/TextDecoration.Android.csproj
+++ b/BoxView/TextDecoration/TextDecoration/TextDecoration.Android/TextDecoration.Android.csproj
@@ -17,6 +17,7 @@
     <AndroidManifest>Properties\AndroidManifest.xml</AndroidManifest>
     <TargetFrameworkVersion>v8.1</TargetFrameworkVersion>
     <JavaMaximumHeapSize />
+    <AndroidHttpClientHandlerType>Xamarin.Android.Net.AndroidClientHandler</AndroidHttpClientHandlerType>
     <NuGetPackageImportStamp />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/BugSweeper/BugSweeper/BugSweeper.Android/BugSweeper.Android.csproj
+++ b/BugSweeper/BugSweeper/BugSweeper.Android/BugSweeper.Android.csproj
@@ -15,6 +15,7 @@
     <AndroidManifest>Properties\AndroidManifest.xml</AndroidManifest>
     <TargetFrameworkVersion>v8.1</TargetFrameworkVersion>
     <JavaMaximumHeapSize>1G</JavaMaximumHeapSize>
+    <AndroidHttpClientHandlerType>Xamarin.Android.Net.AndroidClientHandler</AndroidHttpClientHandlerType>
     <NuGetPackageImportStamp>42f058a4</NuGetPackageImportStamp>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/CatClock/CatClock/CatClock.Android/CatClock.Android.csproj
+++ b/CatClock/CatClock/CatClock.Android/CatClock.Android.csproj
@@ -17,6 +17,7 @@
     <AndroidManifest>Properties\AndroidManifest.xml</AndroidManifest>
     <TargetFrameworkVersion>v8.1</TargetFrameworkVersion>
     <JavaMaximumHeapSize />
+    <AndroidHttpClientHandlerType>Xamarin.Android.Net.AndroidClientHandler</AndroidHttpClientHandlerType>
     <NuGetPackageImportStamp />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/ClassHierarchy/ClassHierarchy/ClassHierarchy.Android/ClassHierarchy.Android.csproj
+++ b/ClassHierarchy/ClassHierarchy/ClassHierarchy.Android/ClassHierarchy.Android.csproj
@@ -15,6 +15,7 @@
     <AndroidManifest>Properties\AndroidManifest.xml</AndroidManifest>
     <TargetFrameworkVersion>v8.1</TargetFrameworkVersion>
     <JavaMaximumHeapSize />
+    <AndroidHttpClientHandlerType>Xamarin.Android.Net.AndroidClientHandler</AndroidHttpClientHandlerType>
     <NuGetPackageImportStamp>8926cf41</NuGetPackageImportStamp>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/CocosSharpForms/Droid/FormsWithCocosSharp.Droid.csproj
+++ b/CocosSharpForms/Droid/FormsWithCocosSharp.Droid.csproj
@@ -14,6 +14,7 @@
     <AndroidResgenFile>Resources\Resource.designer.cs</AndroidResgenFile>
     <AndroidApplication>True</AndroidApplication>
     <AssemblyName>FormsWithCocosSharp.Droid</AssemblyName>
+    <AndroidHttpClientHandlerType>Xamarin.Android.Net.AndroidClientHandler</AndroidHttpClientHandlerType>
     <TargetFrameworkVersion>v8.1</TargetFrameworkVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/CustomRenderers/ContentPage/Droid/CustomRenderer.Droid.csproj
+++ b/CustomRenderers/ContentPage/Droid/CustomRenderer.Droid.csproj
@@ -15,6 +15,7 @@
     <AndroidApplication>True</AndroidApplication>
     <AssemblyName>CustomRenderer.Droid</AssemblyName>
     <TargetFrameworkVersion>v8.1</TargetFrameworkVersion>
+    <AndroidHttpClientHandlerType>Xamarin.Android.Net.AndroidClientHandler</AndroidHttpClientHandlerType>
     <NuGetPackageImportStamp />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/CustomRenderers/Entry/Android/CustomRenderer.Android.csproj
+++ b/CustomRenderers/Entry/Android/CustomRenderer.Android.csproj
@@ -15,6 +15,7 @@
     <AssemblyName>CustomRenderer.Android</AssemblyName>
     <TargetFrameworkVersion>v8.1</TargetFrameworkVersion>
     <AndroidManifest>Properties\AndroidManifest.xml</AndroidManifest>
+    <AndroidHttpClientHandlerType>Xamarin.Android.Net.AndroidClientHandler</AndroidHttpClientHandlerType>
     <NuGetPackageImportStamp />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/CustomRenderers/HybridWebView/Droid/CustomRenderer.Droid.csproj
+++ b/CustomRenderers/HybridWebView/Droid/CustomRenderer.Droid.csproj
@@ -15,6 +15,7 @@
     <AndroidApplication>True</AndroidApplication>
     <AssemblyName>CustomRenderer.Droid</AssemblyName>
     <TargetFrameworkVersion>v8.1</TargetFrameworkVersion>
+    <AndroidHttpClientHandlerType>Xamarin.Android.Net.AndroidClientHandler</AndroidHttpClientHandlerType>
     <NuGetPackageImportStamp />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/CustomRenderers/ListView/Droid/CustomRenderer.Droid.csproj
+++ b/CustomRenderers/ListView/Droid/CustomRenderer.Droid.csproj
@@ -15,6 +15,7 @@
     <AndroidApplication>True</AndroidApplication>
     <AssemblyName>CustomRenderer.Droid</AssemblyName>
     <TargetFrameworkVersion>v8.1</TargetFrameworkVersion>
+    <AndroidHttpClientHandlerType>Xamarin.Android.Net.AndroidClientHandler</AndroidHttpClientHandlerType>
     <NuGetPackageImportStamp />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/CustomRenderers/Map/Circle/Droid/MapOverlay.Droid.csproj
+++ b/CustomRenderers/Map/Circle/Droid/MapOverlay.Droid.csproj
@@ -16,6 +16,7 @@
     <AndroidManifest>Properties\AndroidManifest.xml</AndroidManifest>
     <TargetFrameworkVersion>v8.1</TargetFrameworkVersion>
     <JavaMaximumHeapSize>1G</JavaMaximumHeapSize>
+    <AndroidHttpClientHandlerType>Xamarin.Android.Net.AndroidClientHandler</AndroidHttpClientHandlerType>
     <NuGetPackageImportStamp />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/CustomRenderers/Map/Pin/Droid/CustomRenderer.Droid.csproj
+++ b/CustomRenderers/Map/Pin/Droid/CustomRenderer.Droid.csproj
@@ -16,6 +16,7 @@
     <AssemblyName>CustomRenderer.Droid</AssemblyName>
     <TargetFrameworkVersion>v8.1</TargetFrameworkVersion>
     <JavaMaximumHeapSize>1G</JavaMaximumHeapSize>
+    <AndroidHttpClientHandlerType>Xamarin.Android.Net.AndroidClientHandler</AndroidHttpClientHandlerType>
     <NuGetPackageImportStamp />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/CustomRenderers/Map/Polygon/Droid/MapOverlay.Droid.csproj
+++ b/CustomRenderers/Map/Polygon/Droid/MapOverlay.Droid.csproj
@@ -16,6 +16,7 @@
     <AndroidManifest>Properties\AndroidManifest.xml</AndroidManifest>
     <TargetFrameworkVersion>v8.1</TargetFrameworkVersion>
     <JavaMaximumHeapSize>1G</JavaMaximumHeapSize>
+    <AndroidHttpClientHandlerType>Xamarin.Android.Net.AndroidClientHandler</AndroidHttpClientHandlerType>
     <NuGetPackageImportStamp />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/CustomRenderers/Map/Polyline/Droid/MapOverlay.Droid.csproj
+++ b/CustomRenderers/Map/Polyline/Droid/MapOverlay.Droid.csproj
@@ -16,6 +16,7 @@
     <AndroidManifest>Properties\AndroidManifest.xml</AndroidManifest>
     <TargetFrameworkVersion>v8.1</TargetFrameworkVersion>
     <JavaMaximumHeapSize>1G</JavaMaximumHeapSize>
+    <AndroidHttpClientHandlerType>Xamarin.Android.Net.AndroidClientHandler</AndroidHttpClientHandlerType>
     <NuGetPackageImportStamp />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/CustomRenderers/VideoPlayerDemos/VideoPlayerDemos/VideoPlayerDemos.Android/VideoPlayerDemos.Android.csproj
+++ b/CustomRenderers/VideoPlayerDemos/VideoPlayerDemos/VideoPlayerDemos.Android/VideoPlayerDemos.Android.csproj
@@ -17,6 +17,7 @@
     <AndroidManifest>Properties\AndroidManifest.xml</AndroidManifest>
     <TargetFrameworkVersion>v8.1</TargetFrameworkVersion>
     <JavaMaximumHeapSize />
+    <AndroidHttpClientHandlerType>Xamarin.Android.Net.AndroidClientHandler</AndroidHttpClientHandlerType>
     <NuGetPackageImportStamp />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/CustomRenderers/View/Droid/CustomRenderer.Droid.csproj
+++ b/CustomRenderers/View/Droid/CustomRenderer.Droid.csproj
@@ -15,6 +15,7 @@
     <AndroidApplication>True</AndroidApplication>
     <AssemblyName>CustomRenderer.Droid</AssemblyName>
     <TargetFrameworkVersion>v8.1</TargetFrameworkVersion>
+    <AndroidHttpClientHandlerType>Xamarin.Android.Net.AndroidClientHandler</AndroidHttpClientHandlerType>
     <NuGetPackageImportStamp />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/CustomRenderers/ViewCell/Droid/CustomRenderer.Droid.csproj
+++ b/CustomRenderers/ViewCell/Droid/CustomRenderer.Droid.csproj
@@ -15,6 +15,7 @@
     <AssemblyName>CustomRenderer.Droid</AssemblyName>
     <AndroidManifest>Properties\AndroidManifest.xml</AndroidManifest>
     <TargetFrameworkVersion>v8.1</TargetFrameworkVersion>
+    <AndroidHttpClientHandlerType>Xamarin.Android.Net.AndroidClientHandler</AndroidHttpClientHandlerType>
     <NuGetPackageImportStamp />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/DataBindingDemos/DataBindingDemos/DataBindingDemos.Android/DataBindingDemos.Android.csproj
+++ b/DataBindingDemos/DataBindingDemos/DataBindingDemos.Android/DataBindingDemos.Android.csproj
@@ -18,6 +18,7 @@
     <TargetFrameworkVersion>v8.1</TargetFrameworkVersion>
     <JavaMaximumHeapSize />
     <NuGetPackageImportStamp />
+    <AndroidHttpClientHandlerType>Xamarin.Android.Net.AndroidClientHandler</AndroidHttpClientHandlerType>
     <AndroidUseSharedRuntime>false</AndroidUseSharedRuntime>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/DeepLinking/Droid/DeepLinking.Droid.csproj
+++ b/DeepLinking/Droid/DeepLinking.Droid.csproj
@@ -16,6 +16,7 @@
     <AndroidManifest>Properties\AndroidManifest.xml</AndroidManifest>
     <JavaMaximumHeapSize>1G</JavaMaximumHeapSize>
     <TargetFrameworkVersion>v8.1</TargetFrameworkVersion>
+    <AndroidHttpClientHandlerType>Xamarin.Android.Net.AndroidClientHandler</AndroidHttpClientHandlerType>
     <NuGetPackageImportStamp>716c0aa2</NuGetPackageImportStamp>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/DependencyService/Droid/DependencyServiceSample.Droid.csproj
+++ b/DependencyService/Droid/DependencyServiceSample.Droid.csproj
@@ -15,6 +15,7 @@
     <AndroidApplication>True</AndroidApplication>
     <AssemblyName>DependencyServiceSample.Droid</AssemblyName>
     <TargetFrameworkVersion>v8.1</TargetFrameworkVersion>
+    <AndroidHttpClientHandlerType>Xamarin.Android.Net.AndroidClientHandler</AndroidHttpClientHandlerType>
     <JavaMaximumHeapSize>1G</JavaMaximumHeapSize>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/Effects/BackgroundColorEffect/Droid/EffectsDemo.Droid.csproj
+++ b/Effects/BackgroundColorEffect/Droid/EffectsDemo.Droid.csproj
@@ -15,6 +15,7 @@
     <AndroidApplication>True</AndroidApplication>
     <AssemblyName>EffectsDemo.Droid</AssemblyName>
     <TargetFrameworkVersion>v8.1</TargetFrameworkVersion>
+    <AndroidHttpClientHandlerType>Xamarin.Android.Net.AndroidClientHandler</AndroidHttpClientHandlerType>
     <NuGetPackageImportStamp />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/Effects/FocusEffect/Droid/EffectsDemo.Droid.csproj
+++ b/Effects/FocusEffect/Droid/EffectsDemo.Droid.csproj
@@ -15,6 +15,7 @@
     <AndroidApplication>True</AndroidApplication>
     <AssemblyName>EffectsDemo.Droid</AssemblyName>
     <TargetFrameworkVersion>v8.1</TargetFrameworkVersion>
+    <AndroidHttpClientHandlerType>Xamarin.Android.Net.AndroidClientHandler</AndroidHttpClientHandlerType>
     <NuGetPackageImportStamp />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/Effects/ShadowEffect/Droid/EffectsDemo.Droid.csproj
+++ b/Effects/ShadowEffect/Droid/EffectsDemo.Droid.csproj
@@ -15,6 +15,7 @@
     <AndroidApplication>True</AndroidApplication>
     <AssemblyName>EffectsDemo.Droid</AssemblyName>
     <TargetFrameworkVersion>v8.1</TargetFrameworkVersion>
+    <AndroidHttpClientHandlerType>Xamarin.Android.Net.AndroidClientHandler</AndroidHttpClientHandlerType>
     <NuGetPackageImportStamp />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/Effects/ShadowEffectRuntimeChange/Droid/EffectsDemo.Droid.csproj
+++ b/Effects/ShadowEffectRuntimeChange/Droid/EffectsDemo.Droid.csproj
@@ -15,6 +15,7 @@
     <AndroidApplication>True</AndroidApplication>
     <AssemblyName>EffectsDemo.Droid</AssemblyName>
     <TargetFrameworkVersion>v8.1</TargetFrameworkVersion>
+    <AndroidHttpClientHandlerType>Xamarin.Android.Net.AndroidClientHandler</AndroidHttpClientHandlerType>
     <NuGetPackageImportStamp />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/Effects/TouchTrackingEffect/TouchTrackingEffect/TouchTrackingEffect.Droid/TouchTrackingEffect.Droid.csproj
+++ b/Effects/TouchTrackingEffect/TouchTrackingEffect/TouchTrackingEffect.Droid/TouchTrackingEffect.Droid.csproj
@@ -17,6 +17,7 @@
     <AndroidManifest>Properties\AndroidManifest.xml</AndroidManifest>
     <TargetFrameworkVersion>v8.1</TargetFrameworkVersion>
     <JavaMaximumHeapSize />
+    <AndroidHttpClientHandlerType>Xamarin.Android.Net.AndroidClientHandler</AndroidHttpClientHandlerType>
     <NuGetPackageImportStamp />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/EmployeeDirectory/EmployeeDirectory.Android/EmployeeDirectory.Android.csproj
+++ b/EmployeeDirectory/EmployeeDirectory.Android/EmployeeDirectory.Android.csproj
@@ -16,6 +16,7 @@
     <AndroidManifest>Properties\AndroidManifest.xml</AndroidManifest>
     <TargetFrameworkVersion>v8.1</TargetFrameworkVersion>
     <NuGetPackageImportStamp />
+    <AndroidHttpClientHandlerType>Xamarin.Android.Net.AndroidClientHandler</AndroidHttpClientHandlerType>
     <JavaMaximumHeapSize>1G</JavaMaximumHeapSize>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/Forms2Native/Droid/SimpleColorPicker.Droid.csproj
+++ b/Forms2Native/Droid/SimpleColorPicker.Droid.csproj
@@ -15,6 +15,7 @@
     <AndroidManifest>Properties\AndroidManifest.xml</AndroidManifest>
     <MonoAndroidResourcePrefix>Resources</MonoAndroidResourcePrefix>
     <MonoAndroidAssetsPrefix>Assets</MonoAndroidAssetsPrefix>
+    <AndroidHttpClientHandlerType>Xamarin.Android.Net.AndroidClientHandler</AndroidHttpClientHandlerType>
     <NuGetPackageImportStamp />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/FormsGallery/FormsGallery/FormsGallery.Android/FormsGallery.Android.csproj
+++ b/FormsGallery/FormsGallery/FormsGallery.Android/FormsGallery.Android.csproj
@@ -17,6 +17,7 @@
     <AndroidManifest>Properties\AndroidManifest.xml</AndroidManifest>
     <TargetFrameworkVersion>v8.1</TargetFrameworkVersion>
     <JavaMaximumHeapSize>1G</JavaMaximumHeapSize>
+    <AndroidHttpClientHandlerType>Xamarin.Android.Net.AndroidClientHandler</AndroidHttpClientHandlerType>
     <NuGetPackageImportStamp />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/FormsGridLayout/FormsGridLayout/FormsGridLayout.Android/FormsGridLayout.Android.csproj
+++ b/FormsGridLayout/FormsGridLayout/FormsGridLayout.Android/FormsGridLayout.Android.csproj
@@ -14,6 +14,7 @@
     <AndroidResgenFile>Resources\Resource.Designer.cs</AndroidResgenFile>
     <AndroidManifest>Properties\AndroidManifest.xml</AndroidManifest>
     <TargetFrameworkVersion>v8.1</TargetFrameworkVersion>
+    <AndroidHttpClientHandlerType>Xamarin.Android.Net.AndroidClientHandler</AndroidHttpClientHandlerType>
     <NuGetPackageImportStamp>359bd4ca</NuGetPackageImportStamp>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/GettingStarted/CSSample/CSSample/XamarinFormsSample.Android/XamarinFormsSample.Android.csproj
+++ b/GettingStarted/CSSample/CSSample/XamarinFormsSample.Android/XamarinFormsSample.Android.csproj
@@ -14,6 +14,7 @@
     <AndroidResgenFile>Resources\Resource.Designer.cs</AndroidResgenFile>
     <AndroidManifest>Properties\AndroidManifest.xml</AndroidManifest>
     <TargetFrameworkVersion>v8.1</TargetFrameworkVersion>
+    <AndroidHttpClientHandlerType>Xamarin.Android.Net.AndroidClientHandler</AndroidHttpClientHandlerType>
     <NuGetPackageImportStamp>954a13ee</NuGetPackageImportStamp>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/GettingStarted/HelloFormsXaml/HelloFormsXaml/HelloFormsXaml.Android/HelloFormsXaml.Android.csproj
+++ b/GettingStarted/HelloFormsXaml/HelloFormsXaml/HelloFormsXaml.Android/HelloFormsXaml.Android.csproj
@@ -15,6 +15,7 @@
     <AndroidManifest>Properties\AndroidManifest.xml</AndroidManifest>
     <TargetFrameworkVersion>v8.1</TargetFrameworkVersion>
     <JavaMaximumHeapSize />
+    <AndroidHttpClientHandlerType>Xamarin.Android.Net.AndroidClientHandler</AndroidHttpClientHandlerType>
     <NuGetPackageImportStamp>f944d44e</NuGetPackageImportStamp>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/GettingStarted/HelloXamarinForms/HelloXamarinFormsWorld.Android/HelloXamarinFormsWorld.Android.csproj
+++ b/GettingStarted/HelloXamarinForms/HelloXamarinFormsWorld.Android/HelloXamarinFormsWorld.Android.csproj
@@ -15,6 +15,7 @@
     <AndroidManifest>Properties\AndroidManifest.xml</AndroidManifest>
     <TargetFrameworkVersion>v8.1</TargetFrameworkVersion>
     <JavaMaximumHeapSize />
+    <AndroidHttpClientHandlerType>Xamarin.Android.Net.AndroidClientHandler</AndroidHttpClientHandlerType>
     <NuGetPackageImportStamp>7ffd383b</NuGetPackageImportStamp>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/GettingStarted/XamlSample/XamlSample/XamarinFormsXamlSample.Android/XamarinFormsXamlSample.Android.csproj
+++ b/GettingStarted/XamlSample/XamlSample/XamarinFormsXamlSample.Android/XamarinFormsXamlSample.Android.csproj
@@ -15,6 +15,7 @@
     <AndroidManifest>Properties\AndroidManifest.xml</AndroidManifest>
     <TargetFrameworkVersion>v8.1</TargetFrameworkVersion>
     <JavaMaximumHeapSize />
+    <AndroidHttpClientHandlerType>Xamarin.Android.Net.AndroidClientHandler</AndroidHttpClientHandlerType>
     <NuGetPackageImportStamp>d1ba60e0</NuGetPackageImportStamp>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/LabelledSectionsList/LabelledSectionsList/LabelledSectionsList.Android/LabelledSectionsList.Android.csproj
+++ b/LabelledSectionsList/LabelledSectionsList/LabelledSectionsList.Android/LabelledSectionsList.Android.csproj
@@ -14,6 +14,7 @@
     <AndroidResgenFile>Resources\Resource.Designer.cs</AndroidResgenFile>
     <AndroidManifest>Properties\AndroidManifest.xml</AndroidManifest>
     <TargetFrameworkVersion>v8.1</TargetFrameworkVersion>
+    <AndroidHttpClientHandlerType>Xamarin.Android.Net.AndroidClientHandler</AndroidHttpClientHandlerType>
     <NuGetPackageImportStamp>47b06f17</NuGetPackageImportStamp>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/MobileCRM/MobileCRM.Android/MobileCRM.Android.csproj
+++ b/MobileCRM/MobileCRM.Android/MobileCRM.Android.csproj
@@ -18,6 +18,7 @@
     <NuGetPackageImportStamp>1d834632</NuGetPackageImportStamp>
     <JavaMaximumHeapSize>1G</JavaMaximumHeapSize>
     <AndroidLinkMode>None</AndroidLinkMode>
+    <AndroidHttpClientHandlerType>Xamarin.Android.Net.AndroidClientHandler</AndroidHttpClientHandlerType>
     <AndroidErrorOnCustomJavaObject>false</AndroidErrorOnCustomJavaObject>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/Native2Forms/Droid/Phoneword.Droid.csproj
+++ b/Native2Forms/Droid/Phoneword.Droid.csproj
@@ -14,6 +14,7 @@
     <AndroidResgenClass>Resource</AndroidResgenClass>
     <AndroidManifest>Properties\AndroidManifest.xml</AndroidManifest>
     <MonoAndroidResourcePrefix>Resources</MonoAndroidResourcePrefix>
+    <AndroidHttpClientHandlerType>Xamarin.Android.Net.AndroidClientHandler</AndroidHttpClientHandlerType>
     <MonoAndroidAssetsPrefix>Assets</MonoAndroidAssetsPrefix>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/Navigation/CarouselPage/Droid/CarouselPageNavigation.Droid.csproj
+++ b/Navigation/CarouselPage/Droid/CarouselPageNavigation.Droid.csproj
@@ -15,6 +15,7 @@
     <AssemblyName>CarouselPageNavigation.Droid</AssemblyName>
     <AndroidManifest>Properties\AndroidManifest.xml</AndroidManifest>
     <TargetFrameworkVersion>v8.1</TargetFrameworkVersion>
+    <AndroidHttpClientHandlerType>Xamarin.Android.Net.AndroidClientHandler</AndroidHttpClientHandlerType>
     <NuGetPackageImportStamp />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/Navigation/CarouselPageTemplate/Droid/CarouselPageNavigation.Droid.csproj
+++ b/Navigation/CarouselPageTemplate/Droid/CarouselPageNavigation.Droid.csproj
@@ -15,6 +15,7 @@
     <AssemblyName>CarouselPageNavigation.Droid</AssemblyName>
     <AndroidManifest>Properties\AndroidManifest.xml</AndroidManifest>
     <TargetFrameworkVersion>v8.1</TargetFrameworkVersion>
+    <AndroidHttpClientHandlerType>Xamarin.Android.Net.AndroidClientHandler</AndroidHttpClientHandlerType>
     <NuGetPackageImportStamp />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/Navigation/Hierarchical/Droid/WorkingWithNavigation.Droid.csproj
+++ b/Navigation/Hierarchical/Droid/WorkingWithNavigation.Droid.csproj
@@ -15,6 +15,7 @@
     <AssemblyName>WorkingWithNavigation.Droid</AssemblyName>
     <AndroidManifest>Properties\AndroidManifest.xml</AndroidManifest>
     <TargetFrameworkVersion>v8.1</TargetFrameworkVersion>
+    <AndroidHttpClientHandlerType>Xamarin.Android.Net.AndroidClientHandler</AndroidHttpClientHandlerType>
     <NuGetPackageImportStamp />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/Navigation/LoginFlow/Droid/LoginNavigation.Droid.csproj
+++ b/Navigation/LoginFlow/Droid/LoginNavigation.Droid.csproj
@@ -15,6 +15,7 @@
     <AndroidApplication>True</AndroidApplication>
     <AssemblyName>LoginNavigation.Droid</AssemblyName>
     <TargetFrameworkVersion>v8.1</TargetFrameworkVersion>
+    <AndroidHttpClientHandlerType>Xamarin.Android.Net.AndroidClientHandler</AndroidHttpClientHandlerType>
     <NuGetPackageImportStamp />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/Navigation/MasterDetailPage/Droid/MasterDetailPageNavigation.Droid.csproj
+++ b/Navigation/MasterDetailPage/Droid/MasterDetailPageNavigation.Droid.csproj
@@ -15,6 +15,7 @@
     <AssemblyName>MasterDetailPageNavigation.Droid</AssemblyName>
     <AndroidManifest>Properties\AndroidManifest.xml</AndroidManifest>
     <TargetFrameworkVersion>v8.1</TargetFrameworkVersion>
+    <AndroidHttpClientHandlerType>Xamarin.Android.Net.AndroidClientHandler</AndroidHttpClientHandlerType>
     <NuGetPackageImportStamp />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/Navigation/Modal/Droid/ModalNavigation.Droid.csproj
+++ b/Navigation/Modal/Droid/ModalNavigation.Droid.csproj
@@ -15,6 +15,7 @@
     <AndroidApplication>True</AndroidApplication>
     <AssemblyName>ModalNavigation.Droid</AssemblyName>
     <TargetFrameworkVersion>v8.1</TargetFrameworkVersion>
+    <AndroidHttpClientHandlerType>Xamarin.Android.Net.AndroidClientHandler</AndroidHttpClientHandlerType>
     <NuGetPackageImportStamp />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/Navigation/PassingData/Droid/PassingData.Droid.csproj
+++ b/Navigation/PassingData/Droid/PassingData.Droid.csproj
@@ -15,6 +15,7 @@
     <AndroidApplication>True</AndroidApplication>
     <AssemblyName>PassingData.Droid</AssemblyName>
     <TargetFrameworkVersion>v8.1</TargetFrameworkVersion>
+    <AndroidHttpClientHandlerType>Xamarin.Android.Net.AndroidClientHandler</AndroidHttpClientHandlerType>
     <NuGetPackageImportStamp />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/Navigation/Pop-ups/Android/WorkingWithPopups.Android.csproj
+++ b/Navigation/Pop-ups/Android/WorkingWithPopups.Android.csproj
@@ -15,6 +15,7 @@
     <AssemblyName>WorkingWithPopups.Android</AssemblyName>
     <TargetFrameworkVersion>v8.1</TargetFrameworkVersion>
     <AndroidManifest>Properties\AndroidManifest.xml</AndroidManifest>
+    <AndroidHttpClientHandlerType>Xamarin.Android.Net.AndroidClientHandler</AndroidHttpClientHandlerType>
     <NuGetPackageImportStamp />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/Navigation/TabbedPage/TabbedPageDemo/TabbedPageDemo.Android/TabbedPageDemo.Android.csproj
+++ b/Navigation/TabbedPage/TabbedPageDemo/TabbedPageDemo.Android/TabbedPageDemo.Android.csproj
@@ -15,6 +15,7 @@
     <AndroidManifest>Properties\AndroidManifest.xml</AndroidManifest>
     <TargetFrameworkVersion>v8.1</TargetFrameworkVersion>
     <JavaMaximumHeapSize />
+    <AndroidHttpClientHandlerType>Xamarin.Android.Net.AndroidClientHandler</AndroidHttpClientHandlerType>
     <NuGetPackageImportStamp />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/Navigation/TabbedPageWithNavigationPage/Droid/TabbedPageWithNavigationPage.Droid.csproj
+++ b/Navigation/TabbedPageWithNavigationPage/Droid/TabbedPageWithNavigationPage.Droid.csproj
@@ -15,6 +15,7 @@
     <AndroidApplication>True</AndroidApplication>
     <AssemblyName>TabbedPageWithNavigationPage.Droid</AssemblyName>
     <TargetFrameworkVersion>v8.1</TargetFrameworkVersion>
+    <AndroidHttpClientHandlerType>Xamarin.Android.Net.AndroidClientHandler</AndroidHttpClientHandlerType>
     <NuGetPackageImportStamp />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/Navigation/TitleView/NavigationPageTitleView/NavigationPageTitleView.Android/NavigationPageTitleView.Android.csproj
+++ b/Navigation/TitleView/NavigationPageTitleView/NavigationPageTitleView.Android/NavigationPageTitleView.Android.csproj
@@ -17,8 +17,8 @@
     <MonoAndroidAssetsPrefix>Assets</MonoAndroidAssetsPrefix>
     <AndroidUseLatestPlatformSdk>false</AndroidUseLatestPlatformSdk>
     <TargetFrameworkVersion>v8.1</TargetFrameworkVersion>
-    <NuGetPackageImportStamp>
-    </NuGetPackageImportStamp>
+    <AndroidHttpClientHandlerType>Xamarin.Android.Net.AndroidClientHandler</AndroidHttpClientHandlerType>
+    <NuGetPackageImportStamp></NuGetPackageImportStamp>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/Pages/DataPagesDemo/Droid/DataPagesDemo.Droid.csproj
+++ b/Pages/DataPagesDemo/Droid/DataPagesDemo.Droid.csproj
@@ -16,6 +16,7 @@
     <AssemblyName>DataPagesDemo.Droid</AssemblyName>
     <TargetFrameworkVersion>v8.1</TargetFrameworkVersion>
     <JavaMaximumHeapSize>1G</JavaMaximumHeapSize>
+    <AndroidHttpClientHandlerType>Xamarin.Android.Net.AndroidClientHandler</AndroidHttpClientHandlerType>
     <AndroidUseSharedRuntime>false</AndroidUseSharedRuntime>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/Phoneword/Phoneword/Phoneword.Android/Phoneword.Android.csproj
+++ b/Phoneword/Phoneword/Phoneword.Android/Phoneword.Android.csproj
@@ -16,6 +16,7 @@
     <MonoAndroidResourcePrefix>Resources</MonoAndroidResourcePrefix>
     <MonoAndroidAssetsPrefix>Assets</MonoAndroidAssetsPrefix>
     <TargetFrameworkVersion>v8.1</TargetFrameworkVersion>
+    <AndroidHttpClientHandlerType>Xamarin.Android.Net.AndroidClientHandler</AndroidHttpClientHandlerType>
     <NuGetPackageImportStamp></NuGetPackageImportStamp>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/PhonewordMultiscreen/Phoneword/Phoneword.Android/Phoneword.Android.csproj
+++ b/PhonewordMultiscreen/Phoneword/Phoneword.Android/Phoneword.Android.csproj
@@ -16,6 +16,7 @@
     <MonoAndroidResourcePrefix>Resources</MonoAndroidResourcePrefix>
     <MonoAndroidAssetsPrefix>Assets</MonoAndroidAssetsPrefix>
     <TargetFrameworkVersion>v8.1</TargetFrameworkVersion>
+    <AndroidHttpClientHandlerType>Xamarin.Android.Net.AndroidClientHandler</AndroidHttpClientHandlerType>
     <NuGetPackageImportStamp></NuGetPackageImportStamp>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/RpnCalculator/RpnCalculator/RpnCalculator.Android/RpnCalculator.Android.csproj
+++ b/RpnCalculator/RpnCalculator/RpnCalculator.Android/RpnCalculator.Android.csproj
@@ -17,6 +17,7 @@
     <AndroidManifest>Properties\AndroidManifest.xml</AndroidManifest>
     <TargetFrameworkVersion>v8.1</TargetFrameworkVersion>
     <JavaMaximumHeapSize />
+    <AndroidHttpClientHandlerType>Xamarin.Android.Net.AndroidClientHandler</AndroidHttpClientHandlerType>
     <NuGetPackageImportStamp />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/ScaleAndRotate/ScaleAndRotate/ScaleAndRotate.Android/ScaleAndRotate.Android.csproj
+++ b/ScaleAndRotate/ScaleAndRotate/ScaleAndRotate.Android/ScaleAndRotate.Android.csproj
@@ -15,6 +15,7 @@
     <AndroidManifest>Properties\AndroidManifest.xml</AndroidManifest>
     <TargetFrameworkVersion>v8.1</TargetFrameworkVersion>
     <JavaMaximumHeapSize />
+    <AndroidHttpClientHandlerType>Xamarin.Android.Net.AndroidClientHandler</AndroidHttpClientHandlerType>
     <NuGetPackageImportStamp>a158df9c</NuGetPackageImportStamp>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/Sensors/MonkeySee/MonkeySee/MonkeySee.Android/MonkeySee.Android.csproj
+++ b/Sensors/MonkeySee/MonkeySee/MonkeySee.Android/MonkeySee.Android.csproj
@@ -16,8 +16,8 @@
     <MonoAndroidResourcePrefix>Resources</MonoAndroidResourcePrefix>
     <MonoAndroidAssetsPrefix>Assets</MonoAndroidAssetsPrefix>
     <TargetFrameworkVersion>v8.1</TargetFrameworkVersion>
-    <NuGetPackageImportStamp>
-    </NuGetPackageImportStamp>
+    <AndroidHttpClientHandlerType>Xamarin.Android.Net.AndroidClientHandler</AndroidHttpClientHandlerType>
+    <NuGetPackageImportStamp></NuGetPackageImportStamp>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/Sensors/TiltMaze/TiltMaze/TiltMaze.Android/TiltMaze.Android.csproj
+++ b/Sensors/TiltMaze/TiltMaze/TiltMaze.Android/TiltMaze.Android.csproj
@@ -16,8 +16,8 @@
     <MonoAndroidResourcePrefix>Resources</MonoAndroidResourcePrefix>
     <MonoAndroidAssetsPrefix>Assets</MonoAndroidAssetsPrefix>
     <TargetFrameworkVersion>v8.1</TargetFrameworkVersion>
-    <NuGetPackageImportStamp>
-    </NuGetPackageImportStamp>
+    <AndroidHttpClientHandlerType>Xamarin.Android.Net.AndroidClientHandler</AndroidHttpClientHandlerType>
+    <NuGetPackageImportStamp></NuGetPackageImportStamp>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/SkiaSharpForms/Demos/Demos/SkiaSharpFormsDemos.Droid/SkiaSharpFormsDemos.Droid.csproj
+++ b/SkiaSharpForms/Demos/Demos/SkiaSharpFormsDemos.Droid/SkiaSharpFormsDemos.Droid.csproj
@@ -35,7 +35,6 @@
     <JavaMaximumHeapSize>1G</JavaMaximumHeapSize>
     <AndroidSupportedAbis />
     <AndroidHttpClientHandlerType>Xamarin.Android.Net.AndroidClientHandler</AndroidHttpClientHandlerType>
-    <AndroidTlsProvider>btls</AndroidTlsProvider>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>portable</DebugType>

--- a/SkiaSharpForms/Demos/Demos/SkiaSharpFormsDemos.Droid/SkiaSharpFormsDemos.Droid.csproj
+++ b/SkiaSharpForms/Demos/Demos/SkiaSharpFormsDemos.Droid/SkiaSharpFormsDemos.Droid.csproj
@@ -17,6 +17,7 @@
     <AndroidManifest>Properties\AndroidManifest.xml</AndroidManifest>
     <TargetFrameworkVersion>v8.1</TargetFrameworkVersion>
     <JavaMaximumHeapSize />
+    <AndroidHttpClientHandlerType>Xamarin.Android.Net.AndroidClientHandler</AndroidHttpClientHandlerType>
     <NuGetPackageImportStamp />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
@@ -34,7 +35,6 @@
     <BundleAssemblies>false</BundleAssemblies>
     <JavaMaximumHeapSize>1G</JavaMaximumHeapSize>
     <AndroidSupportedAbis />
-    <AndroidHttpClientHandlerType>Xamarin.Android.Net.AndroidClientHandler</AndroidHttpClientHandlerType>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>portable</DebugType>

--- a/SkiaSharpForms/MandelAnima/MandelAnima/MandelAnima.Android/MandelAnima.Android.csproj
+++ b/SkiaSharpForms/MandelAnima/MandelAnima/MandelAnima.Android/MandelAnima.Android.csproj
@@ -16,6 +16,7 @@
     <MonoAndroidResourcePrefix>Resources</MonoAndroidResourcePrefix>
     <MonoAndroidAssetsPrefix>Assets</MonoAndroidAssetsPrefix>
     <TargetFrameworkVersion>v8.1</TargetFrameworkVersion>
+    <AndroidHttpClientHandlerType>Xamarin.Android.Net.AndroidClientHandler</AndroidHttpClientHandlerType>
     <NuGetPackageImportStamp></NuGetPackageImportStamp>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/SkiaSharpForms/SpinPaint/SpinPaint/SpinPaint.Android/SpinPaint.Android.csproj
+++ b/SkiaSharpForms/SpinPaint/SpinPaint/SpinPaint.Android/SpinPaint.Android.csproj
@@ -17,6 +17,7 @@
     <AndroidManifest>Properties\AndroidManifest.xml</AndroidManifest>
     <TargetFrameworkVersion>v8.1</TargetFrameworkVersion>
     <JavaMaximumHeapSize />
+    <AndroidHttpClientHandlerType>Xamarin.Android.Net.AndroidClientHandler</AndroidHttpClientHandlerType>
     <NuGetPackageImportStamp />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/SkiaSharpForms/SpinPaintShared/SpinPaintShared/SpinPaintShared.Android/SpinPaintShared.Android.csproj
+++ b/SkiaSharpForms/SpinPaintShared/SpinPaintShared/SpinPaintShared.Android/SpinPaintShared.Android.csproj
@@ -17,6 +17,7 @@
     <AndroidManifest>Properties\AndroidManifest.xml</AndroidManifest>
     <TargetFrameworkVersion>v8.1</TargetFrameworkVersion>
     <JavaMaximumHeapSize />
+    <AndroidHttpClientHandlerType>Xamarin.Android.Net.AndroidClientHandler</AndroidHttpClientHandlerType>
     <NuGetPackageImportStamp />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/SolitaireEncryption/Android/Solitaire.Android.csproj
+++ b/SolitaireEncryption/Android/Solitaire.Android.csproj
@@ -14,6 +14,7 @@
     <AndroidApplication>True</AndroidApplication>
     <AssemblyName>Solitaire.Android</AssemblyName>
     <TargetFrameworkVersion>v8.1</TargetFrameworkVersion>
+    <AndroidHttpClientHandlerType>Xamarin.Android.Net.AndroidClientHandler</AndroidHttpClientHandlerType>
     <AndroidManifest>Properties\AndroidManifest.xml</AndroidManifest>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/Templates/ControlTemplates/SimpleTheme/Droid/SimpleTheme.Droid.csproj
+++ b/Templates/ControlTemplates/SimpleTheme/Droid/SimpleTheme.Droid.csproj
@@ -15,6 +15,7 @@
     <AndroidApplication>True</AndroidApplication>
     <AssemblyName>SimpleTheme.Droid</AssemblyName>
     <TargetFrameworkVersion>v8.1</TargetFrameworkVersion>
+    <AndroidHttpClientHandlerType>Xamarin.Android.Net.AndroidClientHandler</AndroidHttpClientHandlerType>
     <NuGetPackageImportStamp />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/Templates/ControlTemplates/SimpleThemeWithTemplateBinding/Droid/SimpleTheme.Droid.csproj
+++ b/Templates/ControlTemplates/SimpleThemeWithTemplateBinding/Droid/SimpleTheme.Droid.csproj
@@ -15,6 +15,7 @@
     <AndroidApplication>True</AndroidApplication>
     <AssemblyName>SimpleTheme.Droid</AssemblyName>
     <TargetFrameworkVersion>v8.1</TargetFrameworkVersion>
+    <AndroidHttpClientHandlerType>Xamarin.Android.Net.AndroidClientHandler</AndroidHttpClientHandlerType>
     <NuGetPackageImportStamp />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/Templates/ControlTemplates/SimpleThemeWithTemplateBindingAndViewModel/Droid/SimpleTheme.Droid.csproj
+++ b/Templates/ControlTemplates/SimpleThemeWithTemplateBindingAndViewModel/Droid/SimpleTheme.Droid.csproj
@@ -15,6 +15,7 @@
     <AndroidApplication>True</AndroidApplication>
     <AssemblyName>SimpleTheme.Droid</AssemblyName>
     <TargetFrameworkVersion>v8.1</TargetFrameworkVersion>
+    <AndroidHttpClientHandlerType>Xamarin.Android.Net.AndroidClientHandler</AndroidHttpClientHandlerType>
     <NuGetPackageImportStamp />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/Templates/DataTemplateSelector/Droid/Selector.Droid.csproj
+++ b/Templates/DataTemplateSelector/Droid/Selector.Droid.csproj
@@ -15,6 +15,7 @@
     <AndroidApplication>True</AndroidApplication>
     <AssemblyName>Selector.Droid</AssemblyName>
     <TargetFrameworkVersion>v8.1</TargetFrameworkVersion>
+    <AndroidHttpClientHandlerType>Xamarin.Android.Net.AndroidClientHandler</AndroidHttpClientHandlerType>
     <NuGetPackageImportStamp />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/Templates/DataTemplates/Droid/DataTemplates.Droid.csproj
+++ b/Templates/DataTemplates/Droid/DataTemplates.Droid.csproj
@@ -15,6 +15,7 @@
     <AndroidApplication>True</AndroidApplication>
     <AssemblyName>DataTemplates.Droid</AssemblyName>
     <TargetFrameworkVersion>v8.1</TargetFrameworkVersion>
+    <AndroidHttpClientHandlerType>Xamarin.Android.Net.AndroidClientHandler</AndroidHttpClientHandlerType>
     <NuGetPackageImportStamp />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/Themes/ThemesDemo/Droid/ThemesDemo.Droid.csproj
+++ b/Themes/ThemesDemo/Droid/ThemesDemo.Droid.csproj
@@ -15,6 +15,7 @@
     <AssemblyName>ThemesDemo.Droid</AssemblyName>
     <AndroidManifest>Properties\AndroidManifest.xml</AndroidManifest>
     <TargetFrameworkVersion>v8.1</TargetFrameworkVersion>
+    <AndroidHttpClientHandlerType>Xamarin.Android.Net.AndroidClientHandler</AndroidHttpClientHandlerType>
     <JavaMaximumHeapSize>1G</JavaMaximumHeapSize>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/TipCalc/TipCalc/TipCalc.Android/TipCalc.Android.csproj
+++ b/TipCalc/TipCalc/TipCalc.Android/TipCalc.Android.csproj
@@ -15,6 +15,7 @@
     <AndroidManifest>Properties\AndroidManifest.xml</AndroidManifest>
     <TargetFrameworkVersion>v8.1</TargetFrameworkVersion>
     <JavaMaximumHeapSize />
+    <AndroidHttpClientHandlerType>Xamarin.Android.Net.AndroidClientHandler</AndroidHttpClientHandlerType>
     <NuGetPackageImportStamp>07fad3cd</NuGetPackageImportStamp>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/Todo/Todo.Android/Todo.Android.csproj
+++ b/Todo/Todo.Android/Todo.Android.csproj
@@ -18,6 +18,7 @@
     <NuGetPackageImportStamp />
     <AndroidUseSharedRuntime>false</AndroidUseSharedRuntime>
     <JavaMaximumHeapSize>1G</JavaMaximumHeapSize>
+    <AndroidHttpClientHandlerType>Xamarin.Android.Net.AndroidClientHandler</AndroidHttpClientHandlerType>
     <AndroidSupportedAbis>armeabi-v7a;x86</AndroidSupportedAbis>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/TodoLocalized/SharedProject/Android/Todo.Android.csproj
+++ b/TodoLocalized/SharedProject/Android/Todo.Android.csproj
@@ -14,6 +14,7 @@
     <AndroidApplication>True</AndroidApplication>
     <AssemblyName>TodoLocalized</AssemblyName>
     <TargetFrameworkVersion>v8.1</TargetFrameworkVersion>
+    <AndroidHttpClientHandlerType>Xamarin.Android.Net.AndroidClientHandler</AndroidHttpClientHandlerType>
     <AndroidManifest>Properties\AndroidManifest.xml</AndroidManifest>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/TodoLocalized/TodoLocalized.Android/TodoLocalized.Android.csproj
+++ b/TodoLocalized/TodoLocalized.Android/TodoLocalized.Android.csproj
@@ -15,6 +15,7 @@
     <AssemblyName>TodoLocalizedAndroid</AssemblyName>
     <AndroidManifest>Properties\AndroidManifest.xml</AndroidManifest>
     <TargetFrameworkVersion>v8.1</TargetFrameworkVersion>
+    <AndroidHttpClientHandlerType>Xamarin.Android.Net.AndroidClientHandler</AndroidHttpClientHandlerType>
     <NuGetPackageImportStamp />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/TodoLocalizedRTL/TodoLocalized.Android/TodoLocalized.Android.csproj
+++ b/TodoLocalizedRTL/TodoLocalized.Android/TodoLocalized.Android.csproj
@@ -16,6 +16,7 @@
     <AndroidManifest>Properties\AndroidManifest.xml</AndroidManifest>
     <TargetFrameworkVersion>v8.1</TargetFrameworkVersion>
     <NuGetPackageImportStamp></NuGetPackageImportStamp>
+    <AndroidHttpClientHandlerType>Xamarin.Android.Net.AndroidClientHandler</AndroidHttpClientHandlerType>
     <JavaMaximumHeapSize>1G</JavaMaximumHeapSize>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/UserInterface/Accessibility/Droid/Accessibility.Droid.csproj
+++ b/UserInterface/Accessibility/Droid/Accessibility.Droid.csproj
@@ -15,6 +15,7 @@
     <MonoAndroidResourcePrefix>Resources</MonoAndroidResourcePrefix>
     <MonoAndroidAssetsPrefix>Assets</MonoAndroidAssetsPrefix>
     <TargetFrameworkVersion>v8.1</TargetFrameworkVersion>
+    <AndroidHttpClientHandlerType>Xamarin.Android.Net.AndroidClientHandler</AndroidHttpClientHandlerType>
     <NuGetPackageImportStamp />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/UserInterface/Animation/Basic/Droid/BasicAnimation.Droid.csproj
+++ b/UserInterface/Animation/Basic/Droid/BasicAnimation.Droid.csproj
@@ -15,6 +15,7 @@
     <AssemblyName>BasicAnimation.Droid</AssemblyName>
     <AndroidManifest>Properties\AndroidManifest.xml</AndroidManifest>
     <TargetFrameworkVersion>v8.1</TargetFrameworkVersion>
+    <AndroidHttpClientHandlerType>Xamarin.Android.Net.AndroidClientHandler</AndroidHttpClientHandlerType>
     <NuGetPackageImportStamp />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/UserInterface/Animation/Custom/Droid/AnimationDemo.Droid.csproj
+++ b/UserInterface/Animation/Custom/Droid/AnimationDemo.Droid.csproj
@@ -15,6 +15,7 @@
     <AssemblyName>AnimationDemo.Droid</AssemblyName>
     <AndroidManifest>Properties\AndroidManifest.xml</AndroidManifest>
     <TargetFrameworkVersion>v8.1</TargetFrameworkVersion>
+    <AndroidHttpClientHandlerType>Xamarin.Android.Net.AndroidClientHandler</AndroidHttpClientHandlerType>
     <NuGetPackageImportStamp />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/UserInterface/Animation/Easing/Droid/EasingDemo.Droid.csproj
+++ b/UserInterface/Animation/Easing/Droid/EasingDemo.Droid.csproj
@@ -15,6 +15,7 @@
     <AssemblyName>EasingDemo.Droid</AssemblyName>
     <AndroidManifest>Properties\AndroidManifest.xml</AndroidManifest>
     <TargetFrameworkVersion>v8.1</TargetFrameworkVersion>
+    <AndroidHttpClientHandlerType>Xamarin.Android.Net.AndroidClientHandler</AndroidHttpClientHandlerType>
     <NuGetPackageImportStamp />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/UserInterface/BindablePicker/BindablePicker/BindablePicker.Droid/BindablePicker.Droid.csproj
+++ b/UserInterface/BindablePicker/BindablePicker/BindablePicker.Droid/BindablePicker.Droid.csproj
@@ -17,6 +17,7 @@
     <AndroidManifest>Properties\AndroidManifest.xml</AndroidManifest>
     <TargetFrameworkVersion>v8.1</TargetFrameworkVersion>
     <JavaMaximumHeapSize />
+    <AndroidHttpClientHandlerType>Xamarin.Android.Net.AndroidClientHandler</AndroidHttpClientHandlerType>
     <NuGetPackageImportStamp />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/UserInterface/BusinessTumble/Droid/TheBusinessTumble.Droid.csproj
+++ b/UserInterface/BusinessTumble/Droid/TheBusinessTumble.Droid.csproj
@@ -14,6 +14,7 @@
     <AndroidResgenFile>Resources\Resource.designer.cs</AndroidResgenFile>
     <AndroidApplication>True</AndroidApplication>
     <AssemblyName>TheBusinessTumble.Droid</AssemblyName>
+    <AndroidHttpClientHandlerType>Xamarin.Android.Net.AndroidClientHandler</AndroidHttpClientHandlerType>
     <TargetFrameworkVersion>v8.1</TargetFrameworkVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/UserInterface/ButtonDemos/ButtonDemos/ButtonDemos.Android/ButtonDemos.Android.csproj
+++ b/UserInterface/ButtonDemos/ButtonDemos/ButtonDemos.Android/ButtonDemos.Android.csproj
@@ -16,6 +16,7 @@
     <MonoAndroidResourcePrefix>Resources</MonoAndroidResourcePrefix>
     <MonoAndroidAssetsPrefix>Assets</MonoAndroidAssetsPrefix>
     <TargetFrameworkVersion>v8.1</TargetFrameworkVersion>
+    <AndroidHttpClientHandlerType>Xamarin.Android.Net.AndroidClientHandler</AndroidHttpClientHandlerType>
     <NuGetPackageImportStamp></NuGetPackageImportStamp>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/UserInterface/CustomLayout/WrapLayout/Droid/ImageWrapLayout.Droid.csproj
+++ b/UserInterface/CustomLayout/WrapLayout/Droid/ImageWrapLayout.Droid.csproj
@@ -15,6 +15,7 @@
     <AndroidManifest>Properties\AndroidManifest.xml</AndroidManifest>
     <MonoAndroidResourcePrefix>Resources</MonoAndroidResourcePrefix>
     <MonoAndroidAssetsPrefix>Assets</MonoAndroidAssetsPrefix>
+    <AndroidHttpClientHandlerType>Xamarin.Android.Net.AndroidClientHandler</AndroidHttpClientHandlerType>
     <NuGetPackageImportStamp />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/UserInterface/DatePicker/DaysBetweenDates/DaysBetweenDates.Android/DaysBetweenDates.Android.csproj
+++ b/UserInterface/DatePicker/DaysBetweenDates/DaysBetweenDates.Android/DaysBetweenDates.Android.csproj
@@ -17,6 +17,7 @@
     <AndroidManifest>Properties\AndroidManifest.xml</AndroidManifest>
     <TargetFrameworkVersion>v8.1</TargetFrameworkVersion>
     <JavaMaximumHeapSize />
+    <AndroidHttpClientHandlerType>Xamarin.Android.Net.AndroidClientHandler</AndroidHttpClientHandlerType>
     <NuGetPackageImportStamp />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/UserInterface/FlexLayoutDemos/FlexLayoutDemos/FlexLayoutDemos.Android/FlexLayoutDemos.Android.csproj
+++ b/UserInterface/FlexLayoutDemos/FlexLayoutDemos/FlexLayoutDemos.Android/FlexLayoutDemos.Android.csproj
@@ -15,6 +15,7 @@
     <AndroidManifest>Properties\AndroidManifest.xml</AndroidManifest>
     <MonoAndroidResourcePrefix>Resources</MonoAndroidResourcePrefix>
     <MonoAndroidAssetsPrefix>Assets</MonoAndroidAssetsPrefix>
+    <AndroidHttpClientHandlerType>Xamarin.Android.Net.AndroidClientHandler</AndroidHttpClientHandlerType>
     <NuGetPackageImportStamp></NuGetPackageImportStamp>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/UserInterface/Layout/Droid/LayoutSamples.Droid.csproj
+++ b/UserInterface/Layout/Droid/LayoutSamples.Droid.csproj
@@ -14,6 +14,7 @@
     <AndroidResgenFile>Resources\Resource.designer.cs</AndroidResgenFile>
     <AndroidApplication>True</AndroidApplication>
     <AssemblyName>LayoutSamples.Droid</AssemblyName>
+    <AndroidHttpClientHandlerType>Xamarin.Android.Net.AndroidClientHandler</AndroidHttpClientHandlerType>
     <TargetFrameworkVersion>v8.1</TargetFrameworkVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/UserInterface/LayoutCompression/Droid/LayoutCompression.Droid.csproj
+++ b/UserInterface/LayoutCompression/Droid/LayoutCompression.Droid.csproj
@@ -14,6 +14,7 @@
     <AndroidResgenClass>Resource</AndroidResgenClass>
     <AndroidManifest>Properties\AndroidManifest.xml</AndroidManifest>
     <MonoAndroidResourcePrefix>Resources</MonoAndroidResourcePrefix>
+    <AndroidHttpClientHandlerType>Xamarin.Android.Net.AndroidClientHandler</AndroidHttpClientHandlerType>
     <MonoAndroidAssetsPrefix>Assets</MonoAndroidAssetsPrefix>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/UserInterface/LayoutOptions/Droid/LayoutOptionsDemo.Droid.csproj
+++ b/UserInterface/LayoutOptions/Droid/LayoutOptionsDemo.Droid.csproj
@@ -15,6 +15,7 @@
     <AndroidManifest>Properties\AndroidManifest.xml</AndroidManifest>
     <MonoAndroidResourcePrefix>Resources</MonoAndroidResourcePrefix>
     <MonoAndroidAssetsPrefix>Assets</MonoAndroidAssetsPrefix>
+    <AndroidHttpClientHandlerType>Xamarin.Android.Net.AndroidClientHandler</AndroidHttpClientHandlerType>
     <NuGetPackageImportStamp />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/UserInterface/ListView/Basics/BasicFormsListView/Droid/BasicFormsListView.Droid.csproj
+++ b/UserInterface/ListView/Basics/BasicFormsListView/Droid/BasicFormsListView.Droid.csproj
@@ -14,6 +14,7 @@
     <AndroidResgenFile>Resources\Resource.designer.cs</AndroidResgenFile>
     <AndroidApplication>True</AndroidApplication>
     <AssemblyName>BasicFormsListView.Droid</AssemblyName>
+    <AndroidHttpClientHandlerType>Xamarin.Android.Net.AndroidClientHandler</AndroidHttpClientHandlerType>
     <TargetFrameworkVersion>v8.1</TargetFrameworkVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/UserInterface/ListView/BindingContextChanged/Droid/BindingContextChanged.Droid.csproj
+++ b/UserInterface/ListView/BindingContextChanged/Droid/BindingContextChanged.Droid.csproj
@@ -15,6 +15,7 @@
     <AssemblyName>BindingContextChanged.Droid</AssemblyName>
     <AndroidManifest>Properties\AndroidManifest.xml</AndroidManifest>
     <TargetFrameworkVersion>v8.1</TargetFrameworkVersion>
+    <AndroidHttpClientHandlerType>Xamarin.Android.Net.AndroidClientHandler</AndroidHttpClientHandlerType>
     <NuGetPackageImportStamp>5ac4f6d2</NuGetPackageImportStamp>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/UserInterface/ListView/BuiltInCells/builtInCellsListView/Droid/builtInCellsListView.Droid.csproj
+++ b/UserInterface/ListView/BuiltInCells/builtInCellsListView/Droid/builtInCellsListView.Droid.csproj
@@ -15,6 +15,7 @@
     <AndroidApplication>True</AndroidApplication>
     <AssemblyName>builtInCellsListView.Droid</AssemblyName>
     <TargetFrameworkVersion>v8.1</TargetFrameworkVersion>
+    <AndroidHttpClientHandlerType>Xamarin.Android.Net.AndroidClientHandler</AndroidHttpClientHandlerType>
     <NuGetPackageImportStamp />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/UserInterface/ListView/CustomCells/sample/Droid/FormsListViewSample.Droid.csproj
+++ b/UserInterface/ListView/CustomCells/sample/Droid/FormsListViewSample.Droid.csproj
@@ -15,6 +15,7 @@
     <AndroidApplication>True</AndroidApplication>
     <AssemblyName>FormsListViewSample.Droid</AssemblyName>
     <TargetFrameworkVersion>v8.1</TargetFrameworkVersion>
+    <AndroidHttpClientHandlerType>Xamarin.Android.Net.AndroidClientHandler</AndroidHttpClientHandlerType>
     <JavaMaximumHeapSize>1G</JavaMaximumHeapSize>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/UserInterface/ListView/DynamicUnevenListCells/Droid/UnevenListCells.Droid.csproj
+++ b/UserInterface/ListView/DynamicUnevenListCells/Droid/UnevenListCells.Droid.csproj
@@ -15,6 +15,7 @@
     <AndroidApplication>True</AndroidApplication>
     <AssemblyName>UnevenListCells.Droid</AssemblyName>
     <TargetFrameworkVersion>v8.1</TargetFrameworkVersion>
+    <AndroidHttpClientHandlerType>Xamarin.Android.Net.AndroidClientHandler</AndroidHttpClientHandlerType>
     <NuGetPackageImportStamp>76fe9557</NuGetPackageImportStamp>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/UserInterface/ListView/Grouping/groupingSampleListView/Droid/groupingSampleListView.Droid.csproj
+++ b/UserInterface/ListView/Grouping/groupingSampleListView/Droid/groupingSampleListView.Droid.csproj
@@ -15,6 +15,7 @@
     <AndroidApplication>True</AndroidApplication>
     <AssemblyName>groupingSampleListView.Droid</AssemblyName>
     <TargetFrameworkVersion>v8.1</TargetFrameworkVersion>
+    <AndroidHttpClientHandlerType>Xamarin.Android.Net.AndroidClientHandler</AndroidHttpClientHandlerType>
     <NuGetPackageImportStamp />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/UserInterface/ListView/Interactivity/interactivityListView/Droid/interactivityListView.Droid.csproj
+++ b/UserInterface/ListView/Interactivity/interactivityListView/Droid/interactivityListView.Droid.csproj
@@ -15,6 +15,7 @@
     <AndroidApplication>True</AndroidApplication>
     <AssemblyName>interactivityListView.Droid</AssemblyName>
     <TargetFrameworkVersion>v8.1</TargetFrameworkVersion>
+    <AndroidHttpClientHandlerType>Xamarin.Android.Net.AndroidClientHandler</AndroidHttpClientHandlerType>
     <NuGetPackageImportStamp />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/UserInterface/ListView/SwitchEntryTwoBinding/twoWayBinding/Droid/twoWayBinding.Droid.csproj
+++ b/UserInterface/ListView/SwitchEntryTwoBinding/twoWayBinding/Droid/twoWayBinding.Droid.csproj
@@ -15,6 +15,7 @@
     <AndroidApplication>True</AndroidApplication>
     <AssemblyName>twoWayBinding.Droid</AssemblyName>
     <TargetFrameworkVersion>v8.1</TargetFrameworkVersion>
+    <AndroidHttpClientHandlerType>Xamarin.Android.Net.AndroidClientHandler</AndroidHttpClientHandlerType>
     <NuGetPackageImportStamp />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/UserInterface/MonkeyAppPicker/Droid/MonkeyApp.Droid.csproj
+++ b/UserInterface/MonkeyAppPicker/Droid/MonkeyApp.Droid.csproj
@@ -15,6 +15,7 @@
     <AndroidManifest>Properties\AndroidManifest.xml</AndroidManifest>
     <MonoAndroidResourcePrefix>Resources</MonoAndroidResourcePrefix>
     <MonoAndroidAssetsPrefix>Assets</MonoAndroidAssetsPrefix>
+    <AndroidHttpClientHandlerType>Xamarin.Android.Net.AndroidClientHandler</AndroidHttpClientHandlerType>
     <NuGetPackageImportStamp />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/UserInterface/NativeEmbedding/NestPlatformControl/NestPlatformControl.Droid/NestPlatformControl.Droid.csproj
+++ b/UserInterface/NativeEmbedding/NestPlatformControl/NestPlatformControl.Droid/NestPlatformControl.Droid.csproj
@@ -15,6 +15,7 @@
     <AndroidManifest>Properties\AndroidManifest.xml</AndroidManifest>
     <TargetFrameworkVersion>v8.1</TargetFrameworkVersion>
     <JavaMaximumHeapSize />
+    <AndroidHttpClientHandlerType>Xamarin.Android.Net.AndroidClientHandler</AndroidHttpClientHandlerType>
     <NuGetPackageImportStamp />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/UserInterface/NativeViews/NativeSwitch/Droid/NativeSwitch.Droid.csproj
+++ b/UserInterface/NativeViews/NativeSwitch/Droid/NativeSwitch.Droid.csproj
@@ -15,6 +15,7 @@
     <AndroidManifest>Properties\AndroidManifest.xml</AndroidManifest>
     <MonoAndroidResourcePrefix>Resources</MonoAndroidResourcePrefix>
     <MonoAndroidAssetsPrefix>Assets</MonoAndroidAssetsPrefix>
+    <AndroidHttpClientHandlerType>Xamarin.Android.Net.AndroidClientHandler</AndroidHttpClientHandlerType>
     <NuGetPackageImportStamp />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/UserInterface/NativeViews/NativeViewInsideContentView/Droid/NativeViewInsideContentView.Droid.csproj
+++ b/UserInterface/NativeViews/NativeViewInsideContentView/Droid/NativeViewInsideContentView.Droid.csproj
@@ -15,6 +15,7 @@
     <AndroidManifest>Properties\AndroidManifest.xml</AndroidManifest>
     <MonoAndroidResourcePrefix>Resources</MonoAndroidResourcePrefix>
     <MonoAndroidAssetsPrefix>Assets</MonoAndroidAssetsPrefix>
+    <AndroidHttpClientHandlerType>Xamarin.Android.Net.AndroidClientHandler</AndroidHttpClientHandlerType>
     <NuGetPackageImportStamp />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/UserInterface/NativeViews/SubclassedNativeControls/Droid/SubclassedNativeControls.Droid.csproj
+++ b/UserInterface/NativeViews/SubclassedNativeControls/Droid/SubclassedNativeControls.Droid.csproj
@@ -14,6 +14,7 @@
     <AndroidResgenClass>Resource</AndroidResgenClass>
     <AndroidManifest>Properties\AndroidManifest.xml</AndroidManifest>
     <MonoAndroidResourcePrefix>Resources</MonoAndroidResourcePrefix>
+    <AndroidHttpClientHandlerType>Xamarin.Android.Net.AndroidClientHandler</AndroidHttpClientHandlerType>
     <MonoAndroidAssetsPrefix>Assets</MonoAndroidAssetsPrefix>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/UserInterface/PickerDemo/Droid/PickerDemo.Droid.csproj
+++ b/UserInterface/PickerDemo/Droid/PickerDemo.Droid.csproj
@@ -15,6 +15,7 @@
     <AndroidManifest>Properties\AndroidManifest.xml</AndroidManifest>
     <MonoAndroidResourcePrefix>Resources</MonoAndroidResourcePrefix>
     <MonoAndroidAssetsPrefix>Assets</MonoAndroidAssetsPrefix>
+    <AndroidHttpClientHandlerType>Xamarin.Android.Net.AndroidClientHandler</AndroidHttpClientHandlerType>
     <NuGetPackageImportStamp />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/UserInterface/PlatformSpecifics/Droid/PlatformSpecifics.Droid.csproj
+++ b/UserInterface/PlatformSpecifics/Droid/PlatformSpecifics.Droid.csproj
@@ -15,6 +15,7 @@
     <AndroidManifest>Properties\AndroidManifest.xml</AndroidManifest>
     <MonoAndroidResourcePrefix>Resources</MonoAndroidResourcePrefix>
     <MonoAndroidAssetsPrefix>Assets</MonoAndroidAssetsPrefix>
+    <AndroidHttpClientHandlerType>Xamarin.Android.Net.AndroidClientHandler</AndroidHttpClientHandlerType>
     <NuGetPackageImportStamp />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/UserInterface/ResponsiveLayout/Droid/Droid.csproj
+++ b/UserInterface/ResponsiveLayout/Droid/Droid.csproj
@@ -14,6 +14,7 @@
     <AndroidResgenFile>Resources\Resource.designer.cs</AndroidResgenFile>
     <AndroidApplication>True</AndroidApplication>
     <AssemblyName>TheBusinessTumble.Droid</AssemblyName>
+    <AndroidHttpClientHandlerType>Xamarin.Android.Net.AndroidClientHandler</AndroidHttpClientHandlerType>
     <TargetFrameworkVersion>v8.1</TargetFrameworkVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/UserInterface/ShadowPlatformSpecific/Droid/ShadowPlatformSpecific.Droid.csproj
+++ b/UserInterface/ShadowPlatformSpecific/Droid/ShadowPlatformSpecific.Droid.csproj
@@ -15,6 +15,7 @@
     <AndroidManifest>Properties\AndroidManifest.xml</AndroidManifest>
     <MonoAndroidResourcePrefix>Resources</MonoAndroidResourcePrefix>
     <MonoAndroidAssetsPrefix>Assets</MonoAndroidAssetsPrefix>
+    <AndroidHttpClientHandlerType>Xamarin.Android.Net.AndroidClientHandler</AndroidHttpClientHandlerType>
     <NuGetPackageImportStamp />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/UserInterface/SliderDemos/SliderDemos/SliderDemos.Android/SliderDemos.Android.csproj
+++ b/UserInterface/SliderDemos/SliderDemos/SliderDemos.Android/SliderDemos.Android.csproj
@@ -17,6 +17,7 @@
     <AndroidManifest>Properties\AndroidManifest.xml</AndroidManifest>
     <TargetFrameworkVersion>v8.1</TargetFrameworkVersion>
     <JavaMaximumHeapSize />
+    <AndroidHttpClientHandlerType>Xamarin.Android.Net.AndroidClientHandler</AndroidHttpClientHandlerType>
     <NuGetPackageImportStamp />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/UserInterface/Styles/BasicStyles/Droid/Styles.Droid.csproj
+++ b/UserInterface/Styles/BasicStyles/Droid/Styles.Droid.csproj
@@ -15,6 +15,7 @@
     <AndroidApplication>True</AndroidApplication>
     <AssemblyName>Styles.Droid</AssemblyName>
     <TargetFrameworkVersion>v8.1</TargetFrameworkVersion>
+    <AndroidHttpClientHandlerType>Xamarin.Android.Net.AndroidClientHandler</AndroidHttpClientHandlerType>
     <NuGetPackageImportStamp />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/UserInterface/Styles/DynamicStyles/Droid/Styles.Droid.csproj
+++ b/UserInterface/Styles/DynamicStyles/Droid/Styles.Droid.csproj
@@ -15,6 +15,7 @@
     <AndroidApplication>True</AndroidApplication>
     <AssemblyName>Styles.Droid</AssemblyName>
     <TargetFrameworkVersion>v8.1</TargetFrameworkVersion>
+    <AndroidHttpClientHandlerType>Xamarin.Android.Net.AndroidClientHandler</AndroidHttpClientHandlerType>
     <NuGetPackageImportStamp />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/UserInterface/Styles/MonkeyAppCSS/MonkeyApp/MonkeyApp.Android/MonkeyApp.Android.csproj
+++ b/UserInterface/Styles/MonkeyAppCSS/MonkeyApp/MonkeyApp.Android/MonkeyApp.Android.csproj
@@ -15,8 +15,8 @@
     <AndroidManifest>Properties\AndroidManifest.xml</AndroidManifest>
     <MonoAndroidResourcePrefix>Resources</MonoAndroidResourcePrefix>
     <MonoAndroidAssetsPrefix>Assets</MonoAndroidAssetsPrefix>
-    <NuGetPackageImportStamp>
-    </NuGetPackageImportStamp>
+    <AndroidHttpClientHandlerType>Xamarin.Android.Net.AndroidClientHandler</AndroidHttpClientHandlerType>
+    <NuGetPackageImportStamp></NuGetPackageImportStamp>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/UserInterface/TableView/TableViewSamples/TableViewSamples.Droid/TableViewSamples.Droid.csproj
+++ b/UserInterface/TableView/TableViewSamples/TableViewSamples.Droid/TableViewSamples.Droid.csproj
@@ -17,6 +17,7 @@
     <TargetFrameworkVersion>v8.1</TargetFrameworkVersion>
     <NuGetPackageImportStamp>0f0fd178</NuGetPackageImportStamp>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
+    <AndroidHttpClientHandlerType>Xamarin.Android.Net.AndroidClientHandler</AndroidHttpClientHandlerType>
     <RestorePackages>true</RestorePackages>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/UserInterface/Text/Droid/TextSample.Droid.csproj
+++ b/UserInterface/Text/Droid/TextSample.Droid.csproj
@@ -15,6 +15,7 @@
     <AndroidApplication>True</AndroidApplication>
     <AssemblyName>TextSample.Droid</AssemblyName>
     <TargetFrameworkVersion>v8.1</TargetFrameworkVersion>
+    <AndroidHttpClientHandlerType>Xamarin.Android.Net.AndroidClientHandler</AndroidHttpClientHandlerType>
     <NuGetPackageImportStamp>7f57b86e</NuGetPackageImportStamp>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/UserInterface/VsmDemos/VsmDemos/VsmDemos.Android/VsmDemos.Android.csproj
+++ b/UserInterface/VsmDemos/VsmDemos/VsmDemos.Android/VsmDemos.Android.csproj
@@ -15,6 +15,7 @@
     <AndroidManifest>Properties\AndroidManifest.xml</AndroidManifest>
     <MonoAndroidResourcePrefix>Resources</MonoAndroidResourcePrefix>
     <MonoAndroidAssetsPrefix>Assets</MonoAndroidAssetsPrefix>
+    <AndroidHttpClientHandlerType>Xamarin.Android.Net.AndroidClientHandler</AndroidHttpClientHandlerType>
     <NuGetPackageImportStamp></NuGetPackageImportStamp>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/UserInterface/WebView/WebViewSample/WebViewSample.Droid/WebViewSample.Droid.csproj
+++ b/UserInterface/WebView/WebViewSample/WebViewSample.Droid/WebViewSample.Droid.csproj
@@ -15,6 +15,7 @@
     <AndroidManifest>Properties\AndroidManifest.xml</AndroidManifest>
     <JavaMaximumHeapSize />
     <TargetFrameworkVersion>v8.1</TargetFrameworkVersion>
+    <AndroidHttpClientHandlerType>Xamarin.Android.Net.AndroidClientHandler</AndroidHttpClientHandlerType>
     <NuGetPackageImportStamp>0615c665</NuGetPackageImportStamp>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/UsingDependencyService/Android/UsingDependencyService.Android.csproj
+++ b/UsingDependencyService/Android/UsingDependencyService.Android.csproj
@@ -14,6 +14,7 @@
     <AndroidResgenFile>Resources\Resource.designer.cs</AndroidResgenFile>
     <AndroidApplication>True</AndroidApplication>
     <AssemblyName>UsingDependencyService.Android</AssemblyName>
+    <AndroidHttpClientHandlerType>Xamarin.Android.Net.AndroidClientHandler</AndroidHttpClientHandlerType>
     <TargetFrameworkVersion>v8.1</TargetFrameworkVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/UsingMessagingCenter/Android/UsingMessagingCenter.Android.csproj
+++ b/UsingMessagingCenter/Android/UsingMessagingCenter.Android.csproj
@@ -14,6 +14,7 @@
     <AndroidApplication>True</AndroidApplication>
     <AssemblyName>UsingMessagingCenter.Android</AssemblyName>
     <TargetFrameworkVersion>v8.1</TargetFrameworkVersion>
+    <AndroidHttpClientHandlerType>Xamarin.Android.Net.AndroidClientHandler</AndroidHttpClientHandlerType>
     <AndroidManifest>Properties\AndroidManifest.xml</AndroidManifest>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/UsingResxLocalization/Android/UsingResxLocalization.Android.csproj
+++ b/UsingResxLocalization/Android/UsingResxLocalization.Android.csproj
@@ -14,6 +14,7 @@
     <AndroidApplication>True</AndroidApplication>
     <AssemblyName>UsingResxLocalization.Android</AssemblyName>
     <TargetFrameworkVersion>v8.1</TargetFrameworkVersion>
+    <AndroidHttpClientHandlerType>Xamarin.Android.Net.AndroidClientHandler</AndroidHttpClientHandlerType>
     <AndroidManifest>Properties\AndroidManifest.xml</AndroidManifest>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/UsingUITest/Droid/UsingUITest.Droid.csproj
+++ b/UsingUITest/Droid/UsingUITest.Droid.csproj
@@ -15,6 +15,7 @@
     <AndroidApplication>True</AndroidApplication>
     <AssemblyName>UsingUITest.Droid</AssemblyName>
     <TargetFrameworkVersion>v8.1</TargetFrameworkVersion>
+    <AndroidHttpClientHandlerType>Xamarin.Android.Net.AndroidClientHandler</AndroidHttpClientHandlerType>
     <NuGetPackageImportStamp>e6475b52</NuGetPackageImportStamp>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/UsingXamarinInsights/Droid/InsightsXamarinFormsTest.Droid.csproj
+++ b/UsingXamarinInsights/Droid/InsightsXamarinFormsTest.Droid.csproj
@@ -14,6 +14,7 @@
     <AndroidResgenFile>Resources\Resource.designer.cs</AndroidResgenFile>
     <AndroidApplication>True</AndroidApplication>
     <AssemblyName>InsightsTestAppForms.Droid</AssemblyName>
+    <AndroidHttpClientHandlerType>Xamarin.Android.Net.AndroidClientHandler</AndroidHttpClientHandlerType>
     <TargetFrameworkVersion>v8.1</TargetFrameworkVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/WebServices/AzureADB2CAuth/Droid/ADB2CAuthorization.Droid.csproj
+++ b/WebServices/AzureADB2CAuth/Droid/ADB2CAuthorization.Droid.csproj
@@ -14,6 +14,7 @@
     <AndroidResgenClass>Resource</AndroidResgenClass>
     <AndroidManifest>Properties\AndroidManifest.xml</AndroidManifest>
     <MonoAndroidResourcePrefix>Resources</MonoAndroidResourcePrefix>
+    <AndroidHttpClientHandlerType>Xamarin.Android.Net.AndroidClientHandler</AndroidHttpClientHandlerType>
     <MonoAndroidAssetsPrefix>Assets</MonoAndroidAssetsPrefix>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/WebServices/AzureSearch/Droid/MonkeyApp.Droid.csproj
+++ b/WebServices/AzureSearch/Droid/MonkeyApp.Droid.csproj
@@ -15,6 +15,7 @@
     <AndroidManifest>Properties\AndroidManifest.xml</AndroidManifest>
     <MonoAndroidResourcePrefix>Resources</MonoAndroidResourcePrefix>
     <MonoAndroidAssetsPrefix>Assets</MonoAndroidAssetsPrefix>
+    <AndroidHttpClientHandlerType>Xamarin.Android.Net.AndroidClientHandler</AndroidHttpClientHandlerType>
     <NuGetPackageImportStamp />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/WebServices/OAuthNativeFlow/Droid/OAuthNativeFlow.Droid.csproj
+++ b/WebServices/OAuthNativeFlow/Droid/OAuthNativeFlow.Droid.csproj
@@ -14,6 +14,7 @@
     <AndroidResgenClass>Resource</AndroidResgenClass>
     <AndroidManifest>Properties\AndroidManifest.xml</AndroidManifest>
     <MonoAndroidResourcePrefix>Resources</MonoAndroidResourcePrefix>
+    <AndroidHttpClientHandlerType>Xamarin.Android.Net.AndroidClientHandler</AndroidHttpClientHandlerType>
     <MonoAndroidAssetsPrefix>Assets</MonoAndroidAssetsPrefix>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/WebServices/TodoASMX/Droid/TodoASMX.Droid.csproj
+++ b/WebServices/TodoASMX/Droid/TodoASMX.Droid.csproj
@@ -14,6 +14,7 @@
     <AndroidApplication>True</AndroidApplication>
     <AssemblyName>TodoASMX.Droid</AssemblyName>
     <AndroidManifest>Properties\AndroidManifest.xml</AndroidManifest>
+    <AndroidHttpClientHandlerType>Xamarin.Android.Net.AndroidClientHandler</AndroidHttpClientHandlerType>
     <TargetFrameworkVersion>v8.1</TargetFrameworkVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/WebServices/TodoAzure/Droid/TodoAzure.Droid.csproj
+++ b/WebServices/TodoAzure/Droid/TodoAzure.Droid.csproj
@@ -17,6 +17,7 @@
     <TargetFrameworkVersion>v8.1</TargetFrameworkVersion>
     <AndroidUseSharedRuntime>False</AndroidUseSharedRuntime>
     <NuGetPackageImportStamp />
+    <AndroidHttpClientHandlerType>Xamarin.Android.Net.AndroidClientHandler</AndroidHttpClientHandlerType>
     <AndroidLinkSkip />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/WebServices/TodoAzureAuth/Droid/TodoAzure.Droid.csproj
+++ b/WebServices/TodoAzureAuth/Droid/TodoAzure.Droid.csproj
@@ -17,6 +17,7 @@
     <TargetFrameworkVersion>v8.1</TargetFrameworkVersion>
     <AndroidUseSharedRuntime>False</AndroidUseSharedRuntime>
     <NuGetPackageImportStamp>29892771</NuGetPackageImportStamp>
+    <AndroidHttpClientHandlerType>Xamarin.Android.Net.AndroidClientHandler</AndroidHttpClientHandlerType>
     <AndroidLinkSkip />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/WebServices/TodoAzureAuthADB2CClientFlow/Droid/TodoAzure.Droid.csproj
+++ b/WebServices/TodoAzureAuthADB2CClientFlow/Droid/TodoAzure.Droid.csproj
@@ -17,6 +17,7 @@
     <TargetFrameworkVersion>v8.1</TargetFrameworkVersion>
     <AndroidUseSharedRuntime>False</AndroidUseSharedRuntime>
     <NuGetPackageImportStamp>29892771</NuGetPackageImportStamp>
+    <AndroidHttpClientHandlerType>Xamarin.Android.Net.AndroidClientHandler</AndroidHttpClientHandlerType>
     <AndroidLinkSkip />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/WebServices/TodoAzureAuthADB2CServerFlow/Droid/TodoAzure.Droid.csproj
+++ b/WebServices/TodoAzureAuthADB2CServerFlow/Droid/TodoAzure.Droid.csproj
@@ -17,6 +17,7 @@
     <TargetFrameworkVersion>v8.1</TargetFrameworkVersion>
     <AndroidUseSharedRuntime>False</AndroidUseSharedRuntime>
     <NuGetPackageImportStamp>29892771</NuGetPackageImportStamp>
+    <AndroidHttpClientHandlerType>Xamarin.Android.Net.AndroidClientHandler</AndroidHttpClientHandlerType>
     <AndroidLinkSkip />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/WebServices/TodoAzureAuthOfflineSync/Droid/TodoAzure.Droid.csproj
+++ b/WebServices/TodoAzureAuthOfflineSync/Droid/TodoAzure.Droid.csproj
@@ -17,6 +17,7 @@
     <TargetFrameworkVersion>v8.1</TargetFrameworkVersion>
     <AndroidUseSharedRuntime>False</AndroidUseSharedRuntime>
     <NuGetPackageImportStamp>29892771</NuGetPackageImportStamp>
+    <AndroidHttpClientHandlerType>Xamarin.Android.Net.AndroidClientHandler</AndroidHttpClientHandlerType>
     <AndroidLinkSkip />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/WebServices/TodoAzurePush/Droid/TodoAzure.Droid.csproj
+++ b/WebServices/TodoAzurePush/Droid/TodoAzure.Droid.csproj
@@ -18,6 +18,7 @@
     <AndroidUseSharedRuntime>False</AndroidUseSharedRuntime>
     <JavaMaximumHeapSize>1G</JavaMaximumHeapSize>
     <NuGetPackageImportStamp />
+    <AndroidHttpClientHandlerType>Xamarin.Android.Net.AndroidClientHandler</AndroidHttpClientHandlerType>
     <AndroidLinkSkip />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/WebServices/TodoCognitiveServices/TodoCognitive.Droid/TodoCognitive.Droid.csproj
+++ b/WebServices/TodoCognitiveServices/TodoCognitive.Droid/TodoCognitive.Droid.csproj
@@ -15,6 +15,7 @@
     <AndroidManifest>Properties\AndroidManifest.xml</AndroidManifest>
     <MonoAndroidResourcePrefix>Resources</MonoAndroidResourcePrefix>
     <MonoAndroidAssetsPrefix>Assets</MonoAndroidAssetsPrefix>
+    <AndroidHttpClientHandlerType>Xamarin.Android.Net.AndroidClientHandler</AndroidHttpClientHandlerType>
     <NuGetPackageImportStamp />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/WebServices/TodoDocumentDB/Droid/TodoDocumentDB.Droid.csproj
+++ b/WebServices/TodoDocumentDB/Droid/TodoDocumentDB.Droid.csproj
@@ -15,6 +15,7 @@
     <AndroidManifest>Properties\AndroidManifest.xml</AndroidManifest>
     <MonoAndroidResourcePrefix>Resources</MonoAndroidResourcePrefix>
     <MonoAndroidAssetsPrefix>Assets</MonoAndroidAssetsPrefix>
+    <AndroidHttpClientHandlerType>Xamarin.Android.Net.AndroidClientHandler</AndroidHttpClientHandlerType>
     <NuGetPackageImportStamp />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/WebServices/TodoDocumentDBAuth/Xamarin.Forms/Droid/TodoDocumentDB.Droid.csproj
+++ b/WebServices/TodoDocumentDBAuth/Xamarin.Forms/Droid/TodoDocumentDB.Droid.csproj
@@ -15,6 +15,7 @@
     <AndroidManifest>Properties\AndroidManifest.xml</AndroidManifest>
     <MonoAndroidResourcePrefix>Resources</MonoAndroidResourcePrefix>
     <MonoAndroidAssetsPrefix>Assets</MonoAndroidAssetsPrefix>
+    <AndroidHttpClientHandlerType>Xamarin.Android.Net.AndroidClientHandler</AndroidHttpClientHandlerType>
     <NuGetPackageImportStamp />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/WebServices/TodoREST/Droid/TodoREST.Droid.csproj
+++ b/WebServices/TodoREST/Droid/TodoREST.Droid.csproj
@@ -17,6 +17,7 @@
     <TargetFrameworkVersion>v8.1</TargetFrameworkVersion>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
     <RestorePackages>true</RestorePackages>
+    <AndroidHttpClientHandlerType>Xamarin.Android.Net.AndroidClientHandler</AndroidHttpClientHandlerType>
     <NuGetPackageImportStamp>16b9ab36</NuGetPackageImportStamp>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/WebServices/TodoWCF/Droid/TodoWCF.Droid.csproj
+++ b/WebServices/TodoWCF/Droid/TodoWCF.Droid.csproj
@@ -14,6 +14,7 @@
     <AndroidResgenFile>Resources\Resource.designer.cs</AndroidResgenFile>
     <AndroidApplication>True</AndroidApplication>
     <AssemblyName>TodoWCF.Droid</AssemblyName>
+    <AndroidHttpClientHandlerType>Xamarin.Android.Net.AndroidClientHandler</AndroidHttpClientHandlerType>
     <TargetFrameworkVersion>v8.1</TargetFrameworkVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/WorkingWithColors/Android/WorkingWithColors.Android.csproj
+++ b/WorkingWithColors/Android/WorkingWithColors.Android.csproj
@@ -14,6 +14,7 @@
     <AndroidApplication>True</AndroidApplication>
     <AssemblyName>WorkingWithColors.Android</AssemblyName>
     <TargetFrameworkVersion>v8.1</TargetFrameworkVersion>
+    <AndroidHttpClientHandlerType>Xamarin.Android.Net.AndroidClientHandler</AndroidHttpClientHandlerType>
     <AndroidManifest>Properties\AndroidManifest.xml</AndroidManifest>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/WorkingWithDevice/Android/WorkingWithDevice.Android.csproj
+++ b/WorkingWithDevice/Android/WorkingWithDevice.Android.csproj
@@ -15,6 +15,7 @@
     <AssemblyName>WorkingWithPlatformSpecifics.Android</AssemblyName>
     <TargetFrameworkVersion>v8.1</TargetFrameworkVersion>
     <AndroidManifest>Properties\AndroidManifest.xml</AndroidManifest>
+    <AndroidHttpClientHandlerType>Xamarin.Android.Net.AndroidClientHandler</AndroidHttpClientHandlerType>
     <NuGetPackageImportStamp />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/WorkingWithFiles/WorkingWithFiles/Android/WorkingWithFiles.Droid.csproj
+++ b/WorkingWithFiles/WorkingWithFiles/Android/WorkingWithFiles.Droid.csproj
@@ -15,6 +15,7 @@
     <AssemblyName>WorkingWithFiles.Android</AssemblyName>
     <TargetFrameworkVersion>v8.1</TargetFrameworkVersion>
     <AndroidManifest>Properties\AndroidManifest.xml</AndroidManifest>
+    <AndroidHttpClientHandlerType>Xamarin.Android.Net.AndroidClientHandler</AndroidHttpClientHandlerType>
     <NuGetPackageImportStamp>c1a67240</NuGetPackageImportStamp>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/WorkingWithFonts/Android/WorkingWithFonts.Android.csproj
+++ b/WorkingWithFonts/Android/WorkingWithFonts.Android.csproj
@@ -14,6 +14,7 @@
     <AndroidApplication>True</AndroidApplication>
     <AssemblyName>WorkingWithFonts.Android</AssemblyName>
     <TargetFrameworkVersion>v8.1</TargetFrameworkVersion>
+    <AndroidHttpClientHandlerType>Xamarin.Android.Net.AndroidClientHandler</AndroidHttpClientHandlerType>
     <AndroidManifest>Properties\AndroidManifest.xml</AndroidManifest>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/WorkingWithGestures/PanGesture/Droid/PanGesture.Droid.csproj
+++ b/WorkingWithGestures/PanGesture/Droid/PanGesture.Droid.csproj
@@ -15,6 +15,7 @@
     <AndroidApplication>True</AndroidApplication>
     <AssemblyName>PanGesture.Droid</AssemblyName>
     <TargetFrameworkVersion>v8.1</TargetFrameworkVersion>
+    <AndroidHttpClientHandlerType>Xamarin.Android.Net.AndroidClientHandler</AndroidHttpClientHandlerType>
     <NuGetPackageImportStamp>7ed3742a</NuGetPackageImportStamp>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/WorkingWithGestures/PinchGesture/Droid/PinchGesture.Droid.csproj
+++ b/WorkingWithGestures/PinchGesture/Droid/PinchGesture.Droid.csproj
@@ -14,6 +14,7 @@
     <AndroidResgenFile>Resources\Resource.designer.cs</AndroidResgenFile>
     <AndroidApplication>True</AndroidApplication>
     <AssemblyName>PinchGesture.Droid</AssemblyName>
+    <AndroidHttpClientHandlerType>Xamarin.Android.Net.AndroidClientHandler</AndroidHttpClientHandlerType>
     <TargetFrameworkVersion>v8.1</TargetFrameworkVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/WorkingWithGestures/SwipeGesture/SwipeGesture.Android/SwipeGesture.Android.csproj
+++ b/WorkingWithGestures/SwipeGesture/SwipeGesture.Android/SwipeGesture.Android.csproj
@@ -17,8 +17,8 @@
     <MonoAndroidAssetsPrefix>Assets</MonoAndroidAssetsPrefix>
     <AndroidUseLatestPlatformSdk>false</AndroidUseLatestPlatformSdk>
     <TargetFrameworkVersion>v8.1</TargetFrameworkVersion>
-    <NuGetPackageImportStamp>
-    </NuGetPackageImportStamp>
+    <AndroidHttpClientHandlerType>Xamarin.Android.Net.AndroidClientHandler</AndroidHttpClientHandlerType>
+    <NuGetPackageImportStamp></NuGetPackageImportStamp>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/WorkingWithGestures/TapGesture/Android/WorkingWithGestures.Android.csproj
+++ b/WorkingWithGestures/TapGesture/Android/WorkingWithGestures.Android.csproj
@@ -14,6 +14,7 @@
     <AndroidApplication>True</AndroidApplication>
     <AssemblyName>WorkingWithGestures.Android</AssemblyName>
     <AndroidManifest>Properties\AndroidManifest.xml</AndroidManifest>
+    <AndroidHttpClientHandlerType>Xamarin.Android.Net.AndroidClientHandler</AndroidHttpClientHandlerType>
     <TargetFrameworkVersion>v8.1</TargetFrameworkVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/WorkingWithImages/WorkingWithImages.Android/WorkingWithImages.Android.csproj
+++ b/WorkingWithImages/WorkingWithImages.Android/WorkingWithImages.Android.csproj
@@ -15,6 +15,7 @@
     <AndroidManifest>Properties\AndroidManifest.xml</AndroidManifest>
     <TargetFrameworkVersion>v8.1</TargetFrameworkVersion>
     <JavaMaximumHeapSize>1G</JavaMaximumHeapSize>
+    <AndroidHttpClientHandlerType>Xamarin.Android.Net.AndroidClientHandler</AndroidHttpClientHandlerType>
     <NuGetPackageImportStamp>67c94730</NuGetPackageImportStamp>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/WorkingWithListview/Android/WorkingWithListview.Android.csproj
+++ b/WorkingWithListview/Android/WorkingWithListview.Android.csproj
@@ -14,6 +14,7 @@
     <AndroidApplication>True</AndroidApplication>
     <AssemblyName>WorkingWithListview.Android</AssemblyName>
     <TargetFrameworkVersion>v8.1</TargetFrameworkVersion>
+    <AndroidHttpClientHandlerType>Xamarin.Android.Net.AndroidClientHandler</AndroidHttpClientHandlerType>
     <AndroidManifest>Properties\AndroidManifest.xml</AndroidManifest>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/WorkingWithListviewNative/Droid/WorkingWithListviewNative.Droid.csproj
+++ b/WorkingWithListviewNative/Droid/WorkingWithListviewNative.Droid.csproj
@@ -14,6 +14,7 @@
     <AndroidApplication>True</AndroidApplication>
     <AssemblyName>WorkingWithListviewPerf.Droid</AssemblyName>
     <AndroidManifest>Properties\AndroidManifest.xml</AndroidManifest>
+    <AndroidHttpClientHandlerType>Xamarin.Android.Net.AndroidClientHandler</AndroidHttpClientHandlerType>
     <TargetFrameworkVersion>v8.1</TargetFrameworkVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/WorkingWithMaps/Android/WorkingWithMaps.Android.csproj
+++ b/WorkingWithMaps/Android/WorkingWithMaps.Android.csproj
@@ -16,6 +16,7 @@
     <TargetFrameworkVersion>v8.1</TargetFrameworkVersion>
     <AndroidManifest>Properties\AndroidManifest.xml</AndroidManifest>
     <JavaMaximumHeapSize>1G</JavaMaximumHeapSize>
+    <AndroidHttpClientHandlerType>Xamarin.Android.Net.AndroidClientHandler</AndroidHttpClientHandlerType>
     <NuGetPackageImportStamp />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/WorkingWithStyles/Android/WorkingWithStyles.Android.csproj
+++ b/WorkingWithStyles/Android/WorkingWithStyles.Android.csproj
@@ -14,6 +14,7 @@
     <AndroidApplication>True</AndroidApplication>
     <AssemblyName>WorkingWithStyles.Android</AssemblyName>
     <TargetFrameworkVersion>v8.1</TargetFrameworkVersion>
+    <AndroidHttpClientHandlerType>Xamarin.Android.Net.AndroidClientHandler</AndroidHttpClientHandlerType>
     <AndroidManifest>Properties\AndroidManifest.xml</AndroidManifest>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/WorkingWithTriggers/WorkingWithTriggers.Android/WorkingWithTriggers.Android.csproj
+++ b/WorkingWithTriggers/WorkingWithTriggers.Android/WorkingWithTriggers.Android.csproj
@@ -15,6 +15,7 @@
     <AndroidManifest>Properties\AndroidManifest.xml</AndroidManifest>
     <TargetFrameworkVersion>v8.1</TargetFrameworkVersion>
     <JavaMaximumHeapSize>1G</JavaMaximumHeapSize>
+    <AndroidHttpClientHandlerType>Xamarin.Android.Net.AndroidClientHandler</AndroidHttpClientHandlerType>
     <NuGetPackageImportStamp>67c94730</NuGetPackageImportStamp>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/WorkingWithWebview/Android/WorkingWithWebview.Android.csproj
+++ b/WorkingWithWebview/Android/WorkingWithWebview.Android.csproj
@@ -15,6 +15,7 @@
     <AssemblyName>WorkingWithWebview.Android</AssemblyName>
     <TargetFrameworkVersion>v8.1</TargetFrameworkVersion>
     <AndroidManifest>Properties\AndroidManifest.xml</AndroidManifest>
+    <AndroidHttpClientHandlerType>Xamarin.Android.Net.AndroidClientHandler</AndroidHttpClientHandlerType>
     <NuGetPackageImportStamp>87338a01</NuGetPackageImportStamp>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/XAML/CallingFactoryMethods/Droid/CallingFactoryMethods.Droid.csproj
+++ b/XAML/CallingFactoryMethods/Droid/CallingFactoryMethods.Droid.csproj
@@ -14,6 +14,7 @@
     <AndroidResgenClass>Resource</AndroidResgenClass>
     <AndroidManifest>Properties\AndroidManifest.xml</AndroidManifest>
     <MonoAndroidResourcePrefix>Resources</MonoAndroidResourcePrefix>
+    <AndroidHttpClientHandlerType>Xamarin.Android.Net.AndroidClientHandler</AndroidHttpClientHandlerType>
     <MonoAndroidAssetsPrefix>Assets</MonoAndroidAssetsPrefix>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/XAML/CoerceValueCallback/Droid/CoerceValueCallback.Droid.csproj
+++ b/XAML/CoerceValueCallback/Droid/CoerceValueCallback.Droid.csproj
@@ -15,6 +15,7 @@
     <AndroidApplication>True</AndroidApplication>
     <AssemblyName>CoerceValueCallback.Droid</AssemblyName>
     <TargetFrameworkVersion>v8.1</TargetFrameworkVersion>
+    <AndroidHttpClientHandlerType>Xamarin.Android.Net.AndroidClientHandler</AndroidHttpClientHandlerType>
     <NuGetPackageImportStamp>118256b2</NuGetPackageImportStamp>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/XAML/MarkupExtensions/MarkupExtensions/MarkupExtensions.Android/MarkupExtensions.Android.csproj
+++ b/XAML/MarkupExtensions/MarkupExtensions/MarkupExtensions.Android/MarkupExtensions.Android.csproj
@@ -17,6 +17,7 @@
     <AndroidManifest>Properties\AndroidManifest.xml</AndroidManifest>
     <TargetFrameworkVersion>v8.1</TargetFrameworkVersion>
     <JavaMaximumHeapSize />
+    <AndroidHttpClientHandlerType>Xamarin.Android.Net.AndroidClientHandler</AndroidHttpClientHandlerType>
     <NuGetPackageImportStamp />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/XAML/PassingConstructorArguments/Droid/PassingConstructorArguments.Droid.csproj
+++ b/XAML/PassingConstructorArguments/Droid/PassingConstructorArguments.Droid.csproj
@@ -14,6 +14,7 @@
     <AndroidResgenClass>Resource</AndroidResgenClass>
     <AndroidManifest>Properties\AndroidManifest.xml</AndroidManifest>
     <MonoAndroidResourcePrefix>Resources</MonoAndroidResourcePrefix>
+    <AndroidHttpClientHandlerType>Xamarin.Android.Net.AndroidClientHandler</AndroidHttpClientHandlerType>
     <MonoAndroidAssetsPrefix>Assets</MonoAndroidAssetsPrefix>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/XAML/ResourceDictionaries/Droid/ResourceDictionaryDemo.Droid.csproj
+++ b/XAML/ResourceDictionaries/Droid/ResourceDictionaryDemo.Droid.csproj
@@ -15,6 +15,7 @@
     <AndroidApplication>True</AndroidApplication>
     <AssemblyName>ResourceDictionaryDemo.Droid</AssemblyName>
     <TargetFrameworkVersion>v8.1</TargetFrameworkVersion>
+    <AndroidHttpClientHandlerType>Xamarin.Android.Net.AndroidClientHandler</AndroidHttpClientHandlerType>
     <NuGetPackageImportStamp />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/XAML/ValidationCallback/Droid/ValidationCallback.Droid.csproj
+++ b/XAML/ValidationCallback/Droid/ValidationCallback.Droid.csproj
@@ -15,6 +15,7 @@
     <AndroidApplication>True</AndroidApplication>
     <AssemblyName>ValidationCallback.Droid</AssemblyName>
     <TargetFrameworkVersion>v8.1</TargetFrameworkVersion>
+    <AndroidHttpClientHandlerType>Xamarin.Android.Net.AndroidClientHandler</AndroidHttpClientHandlerType>
     <NuGetPackageImportStamp>fc5d7421</NuGetPackageImportStamp>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/XamFormsImageResize/Android/XamFormsImageResize.Android.csproj
+++ b/XamFormsImageResize/Android/XamFormsImageResize.Android.csproj
@@ -15,6 +15,7 @@
     <AssemblyName>XamFormsImageResize.Android</AssemblyName>
     <TargetFrameworkVersion>v8.1</TargetFrameworkVersion>
     <AndroidManifest>Properties\AndroidManifest.xml</AndroidManifest>
+    <AndroidHttpClientHandlerType>Xamarin.Android.Net.AndroidClientHandler</AndroidHttpClientHandlerType>
     <NuGetPackageImportStamp>4a0a9468</NuGetPackageImportStamp>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/XamlSamples/XamlSamples/XamlSamples.Android/XamlSamples.Android.csproj
+++ b/XamlSamples/XamlSamples/XamlSamples.Android/XamlSamples.Android.csproj
@@ -17,6 +17,7 @@
     <AndroidManifest>Properties\AndroidManifest.xml</AndroidManifest>
     <TargetFrameworkVersion>v8.1</TargetFrameworkVersion>
     <JavaMaximumHeapSize />
+    <AndroidHttpClientHandlerType>Xamarin.Android.Net.AndroidClientHandler</AndroidHttpClientHandlerType>
     <NuGetPackageImportStamp />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/Xuzzle/Xuzzle/Xuzzle.Android/Xuzzle.Android.csproj
+++ b/Xuzzle/Xuzzle/Xuzzle.Android/Xuzzle.Android.csproj
@@ -15,6 +15,7 @@
     <AndroidManifest>Properties\AndroidManifest.xml</AndroidManifest>
     <TargetFrameworkVersion>v8.1</TargetFrameworkVersion>
     <JavaMaximumHeapSize />
+    <AndroidHttpClientHandlerType>Xamarin.Android.Net.AndroidClientHandler</AndroidHttpClientHandlerType>
     <NuGetPackageImportStamp>033f38f0</NuGetPackageImportStamp>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">


### PR DESCRIPTION
### Description of Change

Force all Android projects to use the Android native network stack, rather than the managed network stack.

### Pull Request Checklist

<!-- Please complete -->

- [x] Rebased on top of master at time of the pull request.
- [ ] Changes adhere to coding standard in the sample.
- [ ] Consolidated NuGet packages across all projects in the sample (when changing existing package versions).
- [x] Tested changes on the appropriate platforms (all platforms if changing the library code).
