### PR TITLE
Make TodoRest.iOS a PackageRef project.

### DIFF
--- a/WebServices/TodoREST/iOS/TodoREST.iOS.csproj
+++ b/WebServices/TodoREST/iOS/TodoREST.iOS.csproj
@@ -14,6 +14,7 @@
     <RestorePackages>true</RestorePackages>
     <NuGetPackageImportStamp>4dbe7b8e</NuGetPackageImportStamp>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+    <RestoreProjectStyle>PackageReference</RestoreProjectStyle>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|iPhoneSimulator' ">
     <DebugSymbols>true</DebugSymbols>


### PR DESCRIPTION
### Description of Change

This fixes a build problem where the iOS project isn't passed the reference to
the referenced .NET Standard project's nuget reference, and the linker ends up
complaining that it can't find the NuGet:

    MTOUCH : error MT2001: Could not link assemblies. Reason: Error while processing references of 'TodoRESTiOS, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null' [/xamarin-forms-samples/WebServices/TodoREST/iOS/TodoREST.iOS.csproj]
      --- inner exception (TaskId:143)
      Mono.Linker.LoadException: Error while processing references of 'TodoRESTiOS, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null' ---> Mono.Cecil.AssemblyResolutionException: Failed to resolve assembly: 'Newtonsoft.Json, Version=10.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed' ---> Mono.Cecil.AssemblyResolutionException: Failed to resolve assembly: 'Newtonsoft.Json, Version=10.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed' (TaskId:143)

Reference: https://github.com/xamarin/xamarin-macios/issues/3949

### Pull Request Checklist

<!-- Please complete -->

- [x] Rebased on top of master at time of the pull request.
- [x] Changes adhere to coding standard in the sample.
- [ ] Consolidated NuGet packages across all projects in the sample (when changing existing package versions).
- [ ] Tested changes on the appropriate platforms (all platforms if changing the library code).