### PR TITLE
[NotificationHubSample] fix for using D8

### DIFF
--- a/WebServices/AzureNotificationHub/NotificationHubSample/NotificationHubSample.Android/NotificationHubSample.Android.csproj
+++ b/WebServices/AzureNotificationHub/NotificationHubSample/NotificationHubSample.Android/NotificationHubSample.Android.csproj
@@ -30,7 +30,6 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <AndroidLinkMode>None</AndroidLinkMode>
-    <AndroidEnableMultiDex>true</AndroidEnableMultiDex>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/WebServices/AzureNotificationHub/NotificationHubSample/NotificationHubSample.Android/Properties/AndroidManifest.xml
+++ b/WebServices/AzureNotificationHub/NotificationHubSample/NotificationHubSample.Android/Properties/AndroidManifest.xml
@@ -13,6 +13,7 @@
 				<category android:name="${applicationId}" />
 			</intent-filter>
 		</receiver>
+		<uses-library android:name="org.apache.http.legacy" android:required="false" />
 	</application>
 	<uses-sdk android:minSdkVersion="21" />
 </manifest>


### PR DESCRIPTION
### Description of Change

Context: https://developer.android.com/about/versions/marshmallow/android-6.0-changes#behavior-apache-http-client

If you build the project with `<AndroidDexTool>d8</AndroidDexTool>`, you will hit:

    R8 : warning : Missing class: org.apache.http.client.methods.HttpEntityEnclosingRequestBase
    R8 : error : Compilation can't be completed because some library classes are missing.

There is a missing `<uses-library/>` element that is needed since Android 6.0.

I also removed the multi-dex setting, since this project does not appear to need it.
### Pull Request Checklist

<!-- Please complete -->

- [x] Rebased on top of master at time of the pull request.
- [x] Changes adhere to coding standard in the sample.
- [ ] Consolidated NuGet packages across all projects in the sample (when changing existing package versions).
- [x] Tested changes on the appropriate platforms (all platforms if changing the library code).
