### PR TITLE
Create and add the flattened conic segments to returned path

### DIFF
--- a/SkiaSharpForms/Demos/Demos/SkiaSharpFormsDemos/Curves/PathExtensions.cs
+++ b/SkiaSharpForms/Demos/Demos/SkiaSharpFormsDemos/Curves/PathExtensions.cs
@@ -153,6 +153,7 @@ namespace SkiaSharpFormsDemos.Curves
                 float y = (1 - t) * (1 - t) * pt0.Y + 2 * weight * t * (1 - t) * pt1.Y + t * t * pt2.Y;
                 x /= denominator;
                 y /= denominator;
+                points[i] = new SKPoint(x, y);
             }
 
             return points;


### PR DESCRIPTION
### Description of Change

Fixes a bug in code related to SkiaSharp.  The flattened points of a conic curve were calculated but not added to the returned set of points.  Compare with the similar code in the other cases to help see that this line was missing.

P.S.
This flattening code is fantastic!  It is a shame that it only exists in a demo.

### Pull Request Checklist

- [x] Rebased on top of master at time of the pull request.
- [x] Changes adhere to coding standard in the sample.
- [x] Consolidated NuGet packages across all projects in the sample (when changing existing package versions).
 - I made no change to package versions.
- [ ] Tested changes on the appropriate platforms (all platforms if changing the library code).
 - I adapted this code in another project and tested there in WPF.  I didn't test on any other platforms.  I doubt such testing is needed.