### PR TITLE
Jusjohns SignalR sample fix

### DIFF
--- a/WebServices/AzureSignalR/ChatClient.UWP/ChatClient.UWP.csproj
+++ b/WebServices/AzureSignalR/ChatClient.UWP/ChatClient.UWP.csproj
@@ -11,7 +11,7 @@
     <AssemblyName>ChatClient.UWP</AssemblyName>
     <DefaultLanguage>en-US</DefaultLanguage>
     <TargetPlatformIdentifier>UAP</TargetPlatformIdentifier>
-    <TargetPlatformVersion>10.0.17763.0</TargetPlatformVersion>
+    <TargetPlatformVersion>10.0.18362.0</TargetPlatformVersion>
     <TargetPlatformMinVersion>10.0.16299.0</TargetPlatformMinVersion>
     <MinimumVisualStudioVersion>14</MinimumVisualStudioVersion>
     <EnableDotNetNativeCompatibleProfile>true</EnableDotNetNativeCompatibleProfile>

--- a/WebServices/AzureSignalR/ChatClient/ChatClient.csproj
+++ b/WebServices/AzureSignalR/ChatClient/ChatClient.csproj
@@ -10,9 +10,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="1.1.0" />
+    <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="3.1.0" />
+    <PackageReference Include="Microsoft.AspNetCore.SignalR.Protocols.NewtonsoftJson" Version="3.1.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="2.2.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.2" />
+    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Include="Xamarin.Forms" Version="4.4.0.991265" />
   </ItemGroup>
 

--- a/WebServices/AzureSignalR/ChatClient/SignalRService.cs
+++ b/WebServices/AzureSignalR/ChatClient/SignalRService.cs
@@ -1,5 +1,6 @@
 ﻿using ChatClient.Model;
 using Microsoft.AspNetCore.SignalR.Client;
+using Microsoft.Extensions.DependencyInjection;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using System;
@@ -52,7 +53,9 @@ namespace ChatClient
 
                 string negotiateJson = await client.GetStringAsync($"{Constants.HostName}/api/negotiate");
                 NegotiateInfo negotiate = JsonConvert.DeserializeObject<NegotiateInfo>(negotiateJson);
+
                 HubConnection connection = new HubConnectionBuilder()
+                    .AddNewtonsoftJsonProtocol()
                     .WithUrl(negotiate.Url, options =>
                     {
                         options.AccessTokenProvider = async () => negotiate.AccessToken;


### PR DESCRIPTION
This PR fixes an issue with the Xam Forms + SignalR sample. A change in the default JSON serialization protocol caused communication to break. You must specify that newtonsoft JSON be used for compatibility.

See: https://github.com/MicrosoftDocs/xamarin-docs/issues/2419