### PR TITLE
Update Microsoft.Extensions.Logging.Console version in SignalR

### DIFF
--- a/WebServices/AzureSignalR/ChatClient/ChatClient.csproj
+++ b/WebServices/AzureSignalR/ChatClient/ChatClient.csproj
@@ -12,7 +12,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="3.1.0" />
     <PackageReference Include="Microsoft.AspNetCore.SignalR.Protocols.NewtonsoftJson" Version="3.1.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="2.2.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="3.1.0" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Include="Xamarin.Forms" Version="4.4.0.991265" />
   </ItemGroup>


### PR DESCRIPTION
Context: https://github.com/xamarin/xamarin-forms-samples/pull/573

The version of `Microsoft.AspNetCore.SignalR.Client` used by SignalR was
recently updated. Both the `Microsoft.AspNetCore.SignalR.Client` and
`Microsoft.Extensions.Logging.Console` packages have a dependency on
`Microsoft.Extensions.Logging`. We should make sure to keep the
version of that shared dependency in sync.

This fixes an issue that would occur when building the SignalR Android
project with the linker enabled:

    /Library/Frameworks/Mono.framework/External/xbuild/Xamarin/Android/Xamarin.Android.Common.targets(1947,5): error XALNK7000: Mono.Linker.MarkException: Error processing method: 'System.IDisposable Microsoft.Extensions.Logging.Console.ConsoleLogger::BeginScope(TState)' in assembly: 'Microsoft.Extensions.Logging.Console.dll' ---> Mono.Cecil.ResolutionException: Failed to resolve Microsoft.Extensions.Logging.Abstractions.Internal.NullScope Microsoft.Extensions.Logging.Abstractions.Internal.NullScope::get_Instance() [WebServices/AzureSignalR/ChatClient.Android/ChatClient.Android.csproj]