### PR TITLE
Update PreviewLayer in LayoutSubviews not Draw

### DIFF
--- a/CustomRenderers/View/iOS/UICameraPreview.cs
+++ b/CustomRenderers/View/iOS/UICameraPreview.cs
@@ -25,10 +25,12 @@ namespace CustomRenderer.iOS
 			Initialize ();
 		}
 
-		public override void Draw (CGRect rect)
+		public override void LayoutSubviews()
 		{
-			base.Draw (rect);
-			previewLayer.Frame = rect;
+			base.LayoutSubviews();
+
+			if (previewLayer != null)
+				previewLayer.Frame = Bounds;
 		}
 
 		public override void TouchesBegan (NSSet touches, UIEvent evt)


### PR DESCRIPTION
### Description of Change

Draw is only called once and is not called if the layout of the view changes.

We had an issue logged here
https://github.com/xamarin/Xamarin.Forms/issues/9623

But you can manifest the same issue by changing the orientation on the device.

- Launch camera sample in portrait
- rotate to landscape

You will notice that without this change the preview window doesn't resize

### Pull Request Checklist

<!-- Please complete -->

- [X] Rebased on top of master at time of the pull request.
- [X] Changes adhere to coding standard in the sample.
- [X] Consolidated NuGet packages across all projects in the sample (when changing existing package versions).
- [X] Tested changes on the appropriate platforms (all platforms if changing the library code).
