### PR TITLE
Added TapGestureRecognizer to MasterDetailPageDemo

### DIFF
--- a/FormsGallery/FormsGallery/FormsGallery/XamlExamples/MasterDetailPageDemoPage.xaml
+++ b/FormsGallery/FormsGallery/FormsGallery/XamlExamples/MasterDetailPageDemoPage.xaml
@@ -54,6 +54,16 @@
             </ContentPage.Resources>
 
             <StackLayout>
+                
+                <!--Provide a way for Android and Windows Phone users to return to master page by tapping the screen-->
+                <StackLayout.GestureRecognizers>
+                    <OnPlatform x:TypeArguments="TapGestureRecognizer">
+                        <On Platform="Android, UWP">
+                            <TapGestureRecognizer Tapped="OnTapGestureRecognizerTapped"/>
+                        </On>
+                    </OnPlatform>
+                </StackLayout.GestureRecognizers>
+
                 <Label Text="{Binding Name}"
                        FontSize="50"
                        HorizontalOptions="Center" />

--- a/FormsGallery/FormsGallery/FormsGallery/XamlExamples/MasterDetailPageDemoPage.xaml.cs
+++ b/FormsGallery/FormsGallery/FormsGallery/XamlExamples/MasterDetailPageDemoPage.xaml.cs
@@ -18,5 +18,10 @@ namespace FormsGallery.XamlExamples
             // Show the detail page.
             IsPresented = false;
         }
+        void OnTapGestureRecognizerTapped(object sender, EventArgs e)
+        {
+            //Show the master page upon tapping the screen
+            IsPresented = true;
+        }
     }
 }


### PR DESCRIPTION
Closes #601 
## Description of Change

Selecting the MasterDetailPageDemo under the  XAML tab only displayed the detail page and had no way to access the master page. CS version of the page added a TapGestureRecognizer to provide a way to reach the master page, so I went on to apply the same logic through the XAML format.

I only managed to test it in an emulated Android 9.0 - API 28 environment. But it should work as intended for other platforms as well. 


### Pull Request Checklist

<!-- Please complete -->

- [ ] Rebased on top of master at time of the pull request.
- [ ] Changes adhere to coding standard in the sample.
- [ ] Consolidated NuGet packages across all projects in the sample (when changing existing package versions).
- [ ] Tested changes on the appropriate platforms (all platforms if changing the library code).
