### PR TITLE
[Android] Localization Sample not localizing text #624

### DIFF
--- a/UsingResxLocalization/UsingResxLocalization/UsingResxLocalization.Android/UsingResxLocalization.Android.csproj
+++ b/UsingResxLocalization/UsingResxLocalization/UsingResxLocalization.Android/UsingResxLocalization.Android.csproj
@@ -124,4 +124,9 @@
     <AndroidResource Include="Resources\drawable\flag.png" />
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\Android\Xamarin.Android.CSharp.targets" />
+  <Target Name="_ResolveSatellitePaths" DependsOnTargets="_ResolveAssemblies">
+    <ResolveAssemblyReference AllowedAssemblyExtensions="$(AllowedReferenceAssemblyFileExtensions)" AssemblyFiles="@(ResolvedUserAssemblies)" AutoUnify="$(AutoUnifyAssemblyReferences)" FindDependencies="True" FindRelatedFiles="False" FindSatellites="True" SearchPaths="$(AssemblySearchPaths)" TargetFrameworkMoniker="$(TargetFrameworkMoniker)" TargetFrameworkMonikerDisplayName="$(TargetFrameworkMonikerDisplayName)" TargetFrameworkDirectories="$(TargetFrameworkDirectory)">
+      <Output TaskParameter="SatelliteFiles" ItemName="_AndroidResolvedSatellitePaths" />
+    </ResolveAssemblyReference>
+  </Target>
 </Project>


### PR DESCRIPTION
### Description of Change

The problem started for me after the last visual studio update (Version 8.6 (build 4520)).

Workaround
This reverts the _ResolveSatellitePaths MSBuild target to the previous implementation as used in Xamarin.Android 10.2.

<!-- Notes:
Do not update the Xamarin.Forms NuGet packages, or Android support libraries.
Do not use pre-release versions of NuGet packages.
If you update a NuGet package in a project, please ensure that you update the same package in the other projects in the sample (if present).
If you change code in the library project in a sample, please ensure that you thoroughly test the changes on all platforms.
If you change code in a platform project in a sample, please ensure that you thoroughly test the change on the platform.
-->

### Pull Request Checklist

<!-- Please complete -->

- [x] Rebased on top of master at time of the pull request.
- [x] Changes adhere to coding standard in the sample.
- [x] Consolidated NuGet packages across all projects in the sample (when changing existing package versions).
- [x] Tested changes on the appropriate platforms (all platforms if changing the library code).
