### PR TITLE
Fix issue with Content Page behaviors

### DIFF
--- a/Behaviors/EventToCommandBehavior/EventToCommandBehavior/Behaviors/EventToCommandBehavior.cs
+++ b/Behaviors/EventToCommandBehavior/EventToCommandBehavior/Behaviors/EventToCommandBehavior.cs
@@ -5,7 +5,7 @@ using Xamarin.Forms;
 
 namespace EventToCommandBehavior
 {
-	public class EventToCommandBehavior : BehaviorBase<View>
+	public class EventToCommandBehavior : BehaviorBase<VisualElement>
 	{
 		Delegate eventHandler;
 
@@ -34,13 +34,13 @@ namespace EventToCommandBehavior
 			set { SetValue (InputConverterProperty, value); }
 		}
 
-		protected override void OnAttachedTo (View bindable)
+		protected override void OnAttachedTo (VisualElement bindable)
 		{
 			base.OnAttachedTo (bindable);
 			RegisterEvent (EventName);
 		}
 
-		protected override void OnDetachingFrom (View bindable)
+		protected override void OnDetachingFrom (VisualElement bindable)
 		{
 			DeregisterEvent (EventName);
 			base.OnDetachingFrom (bindable);


### PR DESCRIPTION
This allows behaviors to be attached to page events via <ContentPage.Behaviors> like Appearing and Disappearing. Without this fix, we get the cryptic following error:

"Additional information: bindable not an instance of AssociatedType"

Original discussion and solution here:
https://forums.xamarin.com/discussion/comment/230200/#Comment_230200

### Description of Change

<!-- Describe your changes here -->

<!-- Notes:
Do not update the Xamarin.Forms NuGet packages, or Android support libraries.
Do not use pre-release versions of NuGet packages.
If you update a NuGet package in a project, please ensure that you update the same package in the other projects in the sample (if present).
If you change code in the library project in a sample, please ensure that you thoroughly test the changes on all platforms.
If you change code in a platform project in a sample, please ensure that you thoroughly test the change on the platform.
-->

### Pull Request Checklist

<!-- Please complete -->

- [ ] Rebased on top of master at time of the pull request.
- [ ] Changes adhere to coding standard in the sample.
- [ ] Consolidated NuGet packages across all projects in the sample (when changing existing package versions).
- [ ] Tested changes on the appropriate platforms (all platforms if changing the library code).
