### PR TITLE
Updating DotMatrix clock to use iOS SafeArea

### DIFF
--- a/BoxView/DotMatrixClock/DotMatrixClock/DotMatrixClock/MainPage.xaml
+++ b/BoxView/DotMatrixClock/DotMatrixClock/DotMatrixClock/MainPage.xaml
@@ -2,9 +2,11 @@
 <ContentPage xmlns="http://xamarin.com/schemas/2014/forms"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              xmlns:local="clr-namespace:DotMatrixClock"
+             xmlns:iOS="clr-namespace:Xamarin.Forms.PlatformConfiguration.iOSSpecific;assembly=Xamarin.Forms.Core"
              x:Class="DotMatrixClock.MainPage"
              Padding="10"
-             SizeChanged="OnPageSizeChanged">
+             SizeChanged="OnPageSizeChanged"
+             iOS:Page.UseSafeArea="True">
 
     <AbsoluteLayout x:Name="absoluteLayout"
                     VerticalOptions="Center" />


### PR DESCRIPTION
### Description of Change

Small change to update the dotmatrix clock sample to use safearea, ensuring the clock does not get lost under the notch in landscape mode.

<!-- Notes:
Do not update the Xamarin.Forms NuGet packages, or Android support libraries.
Do not use pre-release versions of NuGet packages.
If you update a NuGet package in a project, please ensure that you update the same package in the other projects in the sample (if present).
If you change code in the library project in a sample, please ensure that you thoroughly test the changes on all platforms.
If you change code in a platform project in a sample, please ensure that you thoroughly test the change on the platform.
-->

### Pull Request Checklist

<!-- Please complete -->

- [x] Rebased on top of master at time of the pull request.
- [x] Changes adhere to coding standard in the sample.
- [x] Consolidated NuGet packages across all projects in the sample (when changing existing package versions).
- [x] Tested changes on the appropriate platforms (all platforms if changing the library code).
