### PR TITLE
Registeration of DeviceOrientationService in android is missing

### DIFF
--- a/DependencyService/DependencyServiceDemos.Android/MainActivity.cs
+++ b/DependencyService/DependencyServiceDemos.Android/MainActivity.cs
@@ -20,6 +20,7 @@ namespace DependencyServiceDemos.Droid
             global::Xamarin.Forms.Forms.Init(this, savedInstanceState);
             LoadApplication(new App());
             DependencyService.Register<ITextToSpeechService, TextToSpeechService>();
+            DependencyService.Register<IDeviceOrientationService, DeviceOrientationService>();
         }
 
         // Field, property, and method for Picture Picker


### PR DESCRIPTION
I got Null Exception on trying the DeviceOrientationService. After following the code I discovered that DeviceOrientationService registration is missing.
I added it as indicated.

### Description of Change

<!-- Describe your changes here -->

<!-- Notes:
Do not update the Xamarin.Forms NuGet packages, or Android support libraries.
Do not use pre-release versions of NuGet packages.
If you update a NuGet package in a project, please ensure that you update the same package in the other projects in the sample (if present).
If you change code in the library project in a sample, please ensure that you thoroughly test the changes on all platforms.
If you change code in a platform project in a sample, please ensure that you thoroughly test the change on the platform.
-->

### Pull Request Checklist

<!-- Please complete -->

- [-] Rebased on top of master at time of the pull request.
- [X] Changes adhere to coding standard in the sample.
- [NA] Consolidated NuGet packages across all projects in the sample (when changing existing package versions).
- [X] Tested changes on the appropriate platforms (all platforms if changing the library code).
